### PR TITLE
set up backend migration

### DIFF
--- a/imls-backend/.gitignore
+++ b/imls-backend/.gitignore
@@ -1,6 +1,3 @@
 .env
 /data
-/node_modules
-/extensions/displays/unix-timestamp/index.js
-/extensions/panels/wifi/index.js
 .DS_store

--- a/imls-backend/README.md
+++ b/imls-backend/README.md
@@ -1,0 +1,16 @@
+# Backend
+
+## Developer configuration
+
+This is for local configuration only and should never be run in production.
+
+### Run Postgrest
+
+- `docker-compose up`
+
+### Run migrations
+
+- install [dbmate](https://github.com/amacneil/dbmate)
+- configure your `.env` for dbmate:
+  - `DATABASE_URL="postgres://postgres:imlsimls@localhost:5432/imls?sslmode=disable"`
+- `dbmate up`

--- a/imls-backend/db/migrations/20220727163656_init.sql
+++ b/imls-backend/db/migrations/20220727163656_init.sql
@@ -1,0 +1,44 @@
+-- migrate:up
+
+CREATE SCHEMA imlswifi;
+
+CREATE TABLE imlswifi.libraries (
+    fscs_id VARCHAR(16) PRIMARY KEY
+);
+
+CREATE TABLE imlswifi.sensors (
+    sensor_id SERIAL PRIMARY KEY,
+    sensor_serial VARCHAR(32) NOT NULL,
+    sensor_version VARCHAR(16) NOT NULL,
+    fscs_id VARCHAR(16) NOT NULL,
+    CONSTRAINT fk_sensor_library
+        FOREIGN KEY(fscs_id)
+            REFERENCES imlswifi.libraries(fscs_id)
+);
+
+CREATE TABLE imlswifi.presences (
+    presence_id SERIAL PRIMARY KEY,
+    start_time TIMESTAMPTZ NOT NULL,
+    end_time TIMESTAMPTZ NOT NULL,
+    fscs_id VARCHAR(16) NOT NULL,
+    sensor_id SERIAL,
+    CONSTRAINT fk_presence_library
+        FOREIGN KEY (fscs_id)
+            REFERENCES imlswifi.libraries(fscs_id),
+    CONSTRAINT fk_presence_sensor
+        FOREIGN KEY (sensor_id)
+            REFERENCES imlswifi.sensors(sensor_id)
+);
+
+CREATE INDEX fk_sensor_library_index ON imlswifi.sensors(fscs_id);
+
+CREATE INDEX fk_presence_library_index ON imlswifi.presences(fscs_id);
+
+CREATE INDEX fk_presence_sensor_index ON imlswifi.presences(sensor_id);
+
+-- migrate:down
+
+DROP TABLE imlswifi.presences;
+DROP TABLE imlswifi.sensors;
+DROP TABLE imlswifi.libraries;
+DROP SCHEMA imlswifi;

--- a/imls-backend/db/schema.sql
+++ b/imls-backend/db/schema.sql
@@ -1,34 +1,259 @@
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: api; Type: SCHEMA; Schema: -; Owner: -
+--
+
+CREATE SCHEMA api;
+
+
+--
+-- Name: imlswifi; Type: SCHEMA; Schema: -; Owner: -
+--
+
 CREATE SCHEMA imlswifi;
 
-CREATE TABLE imlswifi.libraries (
-    fscs_id VARCHAR PRIMARY KEY
-    -- Unsure of other fields the libraries table needs
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: helo; Type: TABLE; Schema: api; Owner: -
+--
+
+CREATE TABLE api.helo (
+    uid integer NOT NULL,
+    message character varying(42)
 );
 
-CREATE TABLE imlswifi.sensors (
-    sensor_id SERIAL PRIMARY KEY,
-    sensor_serial VARCHAR,
-    sensor_version VARCHAR,
-    heartbeat BOOL,
-    CONSTRAINT fk_sensor_library
-        FOREIGN KEY(fscs_id)
-            REFERENCES imlswifi.libraries(fscs_id)
+
+--
+-- Name: libraries; Type: TABLE; Schema: imlswifi; Owner: -
+--
+
+CREATE TABLE imlswifi.libraries (
+    fscs_id character varying(16) NOT NULL
 );
+
+
+--
+-- Name: presences; Type: TABLE; Schema: imlswifi; Owner: -
+--
 
 CREATE TABLE imlswifi.presences (
-    presence_id SERIAL PRIMARY KEY,
-    start_time TIMESTAMPTZ,
-    end_time TIMESTAMPTZ,
-    CONSTRAINT fk_presence_library
-        FOREIGN KEY (fscs_id)
-            REFERENCES imlswifi.libraries(fscs_id),
-    CONSTRAINT fk_presence_sensor
-        FOREIGN KEY (sensor_id)
-            REFERENCES imlswifi.sensors(sensor_id)
+    presence_id integer NOT NULL,
+    start_time timestamp with time zone NOT NULL,
+    end_time timestamp with time zone NOT NULL,
+    fscs_id character varying(16) NOT NULL,
+    sensor_id integer NOT NULL
 );
 
-CREATE INDEX fk_sensor_library_index ON imlswifi.sensors(fscs_id);
 
-CREATE INDEX fk_presence_library_index ON imlswifi.presences(fscs_id);
+--
+-- Name: presences_presence_id_seq; Type: SEQUENCE; Schema: imlswifi; Owner: -
+--
 
-CREATE INDEX fk_presence_sensor_index ON imlswifi.presences(sensor_id);
+CREATE SEQUENCE imlswifi.presences_presence_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: presences_presence_id_seq; Type: SEQUENCE OWNED BY; Schema: imlswifi; Owner: -
+--
+
+ALTER SEQUENCE imlswifi.presences_presence_id_seq OWNED BY imlswifi.presences.presence_id;
+
+
+--
+-- Name: presences_sensor_id_seq; Type: SEQUENCE; Schema: imlswifi; Owner: -
+--
+
+CREATE SEQUENCE imlswifi.presences_sensor_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: presences_sensor_id_seq; Type: SEQUENCE OWNED BY; Schema: imlswifi; Owner: -
+--
+
+ALTER SEQUENCE imlswifi.presences_sensor_id_seq OWNED BY imlswifi.presences.sensor_id;
+
+
+--
+-- Name: sensors; Type: TABLE; Schema: imlswifi; Owner: -
+--
+
+CREATE TABLE imlswifi.sensors (
+    sensor_id integer NOT NULL,
+    sensor_serial character varying(32) NOT NULL,
+    sensor_version character varying(16) NOT NULL,
+    fscs_id character varying(16) NOT NULL
+);
+
+
+--
+-- Name: sensors_sensor_id_seq; Type: SEQUENCE; Schema: imlswifi; Owner: -
+--
+
+CREATE SEQUENCE imlswifi.sensors_sensor_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: sensors_sensor_id_seq; Type: SEQUENCE OWNED BY; Schema: imlswifi; Owner: -
+--
+
+ALTER SEQUENCE imlswifi.sensors_sensor_id_seq OWNED BY imlswifi.sensors.sensor_id;
+
+
+--
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.schema_migrations (
+    version character varying(255) NOT NULL
+);
+
+
+--
+-- Name: presences presence_id; Type: DEFAULT; Schema: imlswifi; Owner: -
+--
+
+ALTER TABLE ONLY imlswifi.presences ALTER COLUMN presence_id SET DEFAULT nextval('imlswifi.presences_presence_id_seq'::regclass);
+
+
+--
+-- Name: presences sensor_id; Type: DEFAULT; Schema: imlswifi; Owner: -
+--
+
+ALTER TABLE ONLY imlswifi.presences ALTER COLUMN sensor_id SET DEFAULT nextval('imlswifi.presences_sensor_id_seq'::regclass);
+
+
+--
+-- Name: sensors sensor_id; Type: DEFAULT; Schema: imlswifi; Owner: -
+--
+
+ALTER TABLE ONLY imlswifi.sensors ALTER COLUMN sensor_id SET DEFAULT nextval('imlswifi.sensors_sensor_id_seq'::regclass);
+
+
+--
+-- Name: helo helo_pkey; Type: CONSTRAINT; Schema: api; Owner: -
+--
+
+ALTER TABLE ONLY api.helo
+    ADD CONSTRAINT helo_pkey PRIMARY KEY (uid);
+
+
+--
+-- Name: libraries libraries_pkey; Type: CONSTRAINT; Schema: imlswifi; Owner: -
+--
+
+ALTER TABLE ONLY imlswifi.libraries
+    ADD CONSTRAINT libraries_pkey PRIMARY KEY (fscs_id);
+
+
+--
+-- Name: presences presences_pkey; Type: CONSTRAINT; Schema: imlswifi; Owner: -
+--
+
+ALTER TABLE ONLY imlswifi.presences
+    ADD CONSTRAINT presences_pkey PRIMARY KEY (presence_id);
+
+
+--
+-- Name: sensors sensors_pkey; Type: CONSTRAINT; Schema: imlswifi; Owner: -
+--
+
+ALTER TABLE ONLY imlswifi.sensors
+    ADD CONSTRAINT sensors_pkey PRIMARY KEY (sensor_id);
+
+
+--
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: fk_presence_library_index; Type: INDEX; Schema: imlswifi; Owner: -
+--
+
+CREATE INDEX fk_presence_library_index ON imlswifi.presences USING btree (fscs_id);
+
+
+--
+-- Name: fk_presence_sensor_index; Type: INDEX; Schema: imlswifi; Owner: -
+--
+
+CREATE INDEX fk_presence_sensor_index ON imlswifi.presences USING btree (sensor_id);
+
+
+--
+-- Name: fk_sensor_library_index; Type: INDEX; Schema: imlswifi; Owner: -
+--
+
+CREATE INDEX fk_sensor_library_index ON imlswifi.sensors USING btree (fscs_id);
+
+
+--
+-- Name: presences fk_presence_library; Type: FK CONSTRAINT; Schema: imlswifi; Owner: -
+--
+
+ALTER TABLE ONLY imlswifi.presences
+    ADD CONSTRAINT fk_presence_library FOREIGN KEY (fscs_id) REFERENCES imlswifi.libraries(fscs_id);
+
+
+--
+-- Name: presences fk_presence_sensor; Type: FK CONSTRAINT; Schema: imlswifi; Owner: -
+--
+
+ALTER TABLE ONLY imlswifi.presences
+    ADD CONSTRAINT fk_presence_sensor FOREIGN KEY (sensor_id) REFERENCES imlswifi.sensors(sensor_id);
+
+
+--
+-- Name: sensors fk_sensor_library; Type: FK CONSTRAINT; Schema: imlswifi; Owner: -
+--
+
+ALTER TABLE ONLY imlswifi.sensors
+    ADD CONSTRAINT fk_sensor_library FOREIGN KEY (fscs_id) REFERENCES imlswifi.libraries(fscs_id);
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+
+--
+-- Dbmate schema migrations
+--
+
+INSERT INTO public.schema_migrations (version) VALUES
+    ('20220727163656');

--- a/imls-backend/docker-compose.yml
+++ b/imls-backend/docker-compose.yml
@@ -41,7 +41,5 @@ services:
       PGADMIN_DISABLE_POSTFIX: 1
       PGADMIN_LISTEN_ADDRESS: "0.0.0.0"
 
-
-
 networks:
   postgrest:

--- a/imls-backend/docker-compose.yml
+++ b/imls-backend/docker-compose.yml
@@ -27,5 +27,21 @@ services:
     volumes:
       - "./data/database:/var/lib/postgresql/data"
       - "./init:/docker-entrypoint-initdb.d"
+  admin:
+    image: dpage/pgadmin4:6.12
+    ports:
+      - "8080:80"
+    networks:
+      - postgrest
+    environment:
+      # connection string in the app is host.docker.internal
+      # user is `postgres` (or as above), password is as below.
+      PGADMIN_DEFAULT_EMAIL: "${PGADMIN_DEFAULT_EMAIL:-imls@gsa.gov}"
+      PGADMIN_DEFAULT_PASSWORD: "${POSTGRES_PASSWORD:-imlsimls}"
+      PGADMIN_DISABLE_POSTFIX: 1
+      PGADMIN_LISTEN_ADDRESS: "0.0.0.0"
+
+
+
 networks:
   postgrest:

--- a/imls-backend/docker-compose.yml
+++ b/imls-backend/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: postgrest/postgrest
     ports:
       - "3000:3000"
+    networks:
+      - postgrest
     environment:
       PGRST_DB_URI: "postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-imlsimls}@db:5432/${POSTGRES_DB:-imls}"
       PGRST_DB_SCHEMAS: public
@@ -16,6 +18,8 @@ services:
     image: postgres:14.4-alpine
     ports:
       - "5432:5432"
+    networks:
+      - postgrest
     environment:
       POSTGRES_DB: "${POSTGRES_DB:-imls}"
       POSTGRES_USER: "${POSTGRES_USER:-postgres}"
@@ -23,3 +27,5 @@ services:
     volumes:
       - "./data/database:/var/lib/postgresql/data"
       - "./init:/docker-entrypoint-initdb.d"
+networks:
+  postgrest:


### PR DESCRIPTION
- tweaks docker-compose to run in its network
- adds dbmate support via schema.sql and initial migration
- adds some extra restrictions on the initial fields (mostly varchar limits)
- adds FK fields (was necessary to get this working as a migration)
- adds README!