### PR TITLE
Megalinter exclude tests, old commits

### DIFF
--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -86,8 +86,14 @@ jobs:
           branch: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref }}
           commit_message: "[MegaLinter] Apply linters fixes"
 
+      - name: Check to see if the SARIF a was generated
+        id: sarif_file_exists
+        uses: andstor/file-existence-action@v1
+        with:
+          files: "megalinter-reports/megalinter-report.sarif"
+
       - name: Upload MegaLinter scan results to GitHub Security tab
-        if: ${{ success() }} || ${{ failure() }}
+        if: steps.sarif_file_exists.outputs.files_exists == 'true'
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: "megalinter-reports/megalinter-report.sarif"

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
+          fetch-depth: 1
 
       # MegaLinter
       - name: MegaLinter
@@ -42,8 +42,7 @@ jobs:
         env:
           # All available variables are described in documentation
           # https://oxsecurity.github.io/megalinter/configuration/
-          # VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }} # Validates all source when push on main, else just the git diff with main. Override with true if you always want to lint all sources
-          VALIDATE_ALL_CODEBASE: true # always validate everything
+          VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }} # Validates all source when push on main, else just the git diff with main. Override with true if you always want to lint all sources
 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # ADD YOUR CUSTOM ENV VARIABLES HERE OR DEFINE THEM IN A FILE .mega-linter.yml AT THE ROOT OF YOUR REPOSITORY

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,6 +1,6 @@
 ---
 # don't use Mega-Linter to test the reports Mega-Linter created
-ADDITIONAL_EXCLUDED_DIRECTORIES: [report, megalinter-reports]
+ADDITIONAL_EXCLUDED_DIRECTORIES: [report, megalinter-reports, test, tests]
 
 # don't scan files listed in .gitignore (e.g., node_modules)
 IGNORE_GITIGNORED_FILES: true

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -2,6 +2,7 @@
 # don't utest the reports Mega-Linter created or test files
 ADDITIONAL_EXCLUDED_DIRECTORIES: [report, megalinter-reports, test, tests]
 
+# don't lint test files
 FILTER_REGEX_EXCLUDE: (/test/|\.test\.|_test\.)
 
 # don't scan files listed in .gitignore (e.g., node_modules)
@@ -34,4 +35,5 @@ SARIF_REPORTER: true
 # make individual checks available to the status reporter
 GITHUB_STATUS_REPORTER: true
 
+# only scan the files in This commit, not the entire history of the repo
 REPOSITORY_GITLEAKS_ARGUMENTS: --no-git

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,6 +1,8 @@
 ---
-# don't use Mega-Linter to test the reports Mega-Linter created
+# don't utest the reports Mega-Linter created or test files
 ADDITIONAL_EXCLUDED_DIRECTORIES: [report, megalinter-reports, test, tests]
+
+FILTER_REGEX_EXCLUDE: "(/test/|/test$|\.test\.|_test\.)"
 
 # don't scan files listed in .gitignore (e.g., node_modules)
 IGNORE_GITIGNORED_FILES: true

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -33,3 +33,5 @@ SARIF_REPORTER: true
 
 # make individual checks available to the status reporter
 GITHUB_STATUS_REPORTER: true
+
+REPOSITORY_GITLEAKS_ARGUMENTS: --no-git

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -2,7 +2,7 @@
 # don't utest the reports Mega-Linter created or test files
 ADDITIONAL_EXCLUDED_DIRECTORIES: [report, megalinter-reports, test, tests]
 
-FILTER_REGEX_EXCLUDE: "(/test/|/test$|\.test\.|_test\.)"
+FILTER_REGEX_EXCLUDE: (/test/|\.test\.|_test\.)
 
 # don't scan files listed in .gitignore (e.g., node_modules)
 IGNORE_GITIGNORED_FILES: true


### PR DESCRIPTION
This reduces scan depth to avoid matching non-existent files and speed up scan results.  As a result, Megalinter SARIF reports are working again.