### PR TITLE
remove patron index

### DIFF
--- a/imls-backend/README.md
+++ b/imls-backend/README.md
@@ -36,7 +36,6 @@ This is for local configuration only and should never be run in production.
   - fscs_id VARCHAR(16) NOT NULL [FOREIGN KEY],
   - sensor_id SERIAL [FOREIGN KEY],
   - manufacturer_index INTEGER,
-  - patron_index INTEGER,
 
 ## Persisted Data
 

--- a/imls-backend/db/migrations/20220811194424_drop_patron_index.sql
+++ b/imls-backend/db/migrations/20220811194424_drop_patron_index.sql
@@ -1,0 +1,10 @@
+-- migrate:up
+
+DROP VIEW api.presences;
+ALTER TABLE imlswifi.presences DROP COLUMN patron_index;
+CREATE VIEW api.presences AS SELECT * FROM imlswifi.presences;
+GRANT SELECT ON TABLE api.presences TO web_anon;
+
+-- migrate:down
+
+ALTER TABLE imlswifi.presences ADD COLUMN patron_index INTEGER;

--- a/imls-backend/db/schema.sql
+++ b/imls-backend/db/schema.sql
@@ -47,8 +47,7 @@ CREATE TABLE imlswifi.presences (
     end_time timestamp with time zone NOT NULL,
     fscs_id character varying(16) NOT NULL,
     sensor_id integer NOT NULL,
-    manufacturer_index integer,
-    patron_index integer
+    manufacturer_index integer
 );
 
 
@@ -62,8 +61,7 @@ CREATE VIEW api.presences AS
     presences.end_time,
     presences.fscs_id,
     presences.sensor_id,
-    presences.manufacturer_index,
-    presences.patron_index
+    presences.manufacturer_index
    FROM imlswifi.presences;
 
 
@@ -327,4 +325,5 @@ ALTER TABLE ONLY imlswifi.sensors
 INSERT INTO public.schema_migrations (version) VALUES
     ('20220727163656'),
     ('20220729132839'),
-    ('20220729150547');
+    ('20220729150547'),
+    ('20220811194424');

--- a/imls-raspberry-pi/cmd/session-counter/structs/durations.go
+++ b/imls-raspberry-pi/cmd/session-counter/structs/durations.go
@@ -27,7 +27,6 @@ type Duration struct {
 	SessionID int64  `json:"session_id" db:"session_id" type:"TEXT"`
 	FCFSSeqID string `json:"fcfs_seq_id" db:"fcfs_seq_id" type:"TEXT"`
 	DeviceTag string `json:"device_tag" db:"device_tag" type:"TEXT"`
-	PatronID  int    `json:"patron_index" db:"patron_index" type:"INTEGER"`
 	Start     int64  `json:"start,string" db:"start" type:"INTEGER"`
 	End       int64  `json:"end,string" db:"end" type:"INTEGER"`
 }

--- a/imls-raspberry-pi/cmd/session-counter/tlp/process_data.go
+++ b/imls-raspberry-pi/cmd/session-counter/tlp/process_data.go
@@ -21,7 +21,6 @@ func ProcessData(dDB *state.DurationsDB, sq *state.Queue[int64]) bool {
 		sq.Enqueue(thissession)
 	}
 
-	pidCounter := 0
 	durations := make([]*structs.Duration, 0)
 
 	for _, se := range state.GetMACs() {
@@ -31,13 +30,11 @@ func ProcessData(dDB *state.DurationsDB, sq *state.Queue[int64]) bool {
 			SessionID: state.GetCurrentSessionID(),
 			FCFSSeqID: config.GetFCFSSeqID(),
 			DeviceTag: config.GetDeviceTag(),
-			PatronID:  pidCounter,
 			Start:     se.Start,
 			End:       se.End,
 		}
 
 		durations = append(durations, d)
-		pidCounter += 1
 	}
 
 	dDB.InsertMany(durations)


### PR DESCRIPTION
addresses #118 

- do not POST patron id anymore
- schema migration to remove the patron_index from the imlswifi.durations table 