### PR TITLE
fix fcfs misspelling, rename duration fields

### DIFF
--- a/imls-raspberry-pi/cmd/session-counter/session-counter.go
+++ b/imls-raspberry-pi/cmd/session-counter/session-counter.go
@@ -86,7 +86,7 @@ func launchTLP() {
 		zls.SetupZeroLogSentry("session-counter", dsn)
 		zls.SetTags(map[string]string{
 			"tag":     config.GetDeviceTag(),
-			"fcfs_id": config.GetFCFSSeqID(),
+			"fscs_id": config.GetFSCSID(),
 		})
 	}
 

--- a/imls-raspberry-pi/cmd/session-counter/structs/durations.go
+++ b/imls-raspberry-pi/cmd/session-counter/structs/durations.go
@@ -22,13 +22,13 @@ type Durations struct {
 }
 
 type Duration struct {
-	ID        int    `json:"id" db:"id" type:"INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL"`
-	PiSerial  string `json:"pi_serial" db:"pi_serial" type:"TEXT"`
-	SessionID int64  `json:"session_id" db:"session_id" type:"TEXT"`
-	FCFSSeqID string `json:"fcfs_seq_id" db:"fcfs_seq_id" type:"TEXT"`
-	DeviceTag string `json:"device_tag" db:"device_tag" type:"TEXT"`
-	Start     int64  `json:"start,string" db:"start" type:"INTEGER"`
-	End       int64  `json:"end,string" db:"end" type:"INTEGER"`
+	ID        int    `json:"id"`
+	Serial    string `json:"serial"`
+	SessionID int64  `json:"session_id"`
+	FSCSID    string `json:"fscs"`
+	DeviceTag string `json:"device_tag"`
+	Start     int64  `json:"start_time,string"`
+	End       int64  `json:"end_time,string"`
 }
 
 func (d Duration) AsMap() map[string]interface{} {

--- a/imls-raspberry-pi/cmd/session-counter/tlp/process_data.go
+++ b/imls-raspberry-pi/cmd/session-counter/tlp/process_data.go
@@ -26,9 +26,9 @@ func ProcessData(dDB *state.DurationsDB, sq *state.Queue[int64]) bool {
 	for _, se := range state.GetMACs() {
 
 		d := &structs.Duration{
-			PiSerial:  state.GetCachedSerial(),
+			Serial:    state.GetCachedSerial(),
 			SessionID: state.GetCurrentSessionID(),
-			FCFSSeqID: config.GetFCFSSeqID(),
+			FSCSID:    config.GetFSCSID(),
 			DeviceTag: config.GetDeviceTag(),
 			Start:     se.Start,
 			End:       se.End,

--- a/imls-raspberry-pi/cmd/session-counter/tlp/shark_test.go
+++ b/imls-raspberry-pi/cmd/session-counter/tlp/shark_test.go
@@ -22,7 +22,7 @@ func setup() {
 
 	config.SetConfigAtPath(temp.Name())
 	config.SetRunMode("test")
-	config.SetFCFSSeqID("ME0000-001")
+	config.SetFSCSID("ME0000-001")
 	config.SetDeviceTag("testing")
 
 	log.Debug().Int64("session id", state.GetCurrentSessionID()).Msg("setup")

--- a/imls-raspberry-pi/internal/config/config.go
+++ b/imls-raspberry-pi/internal/config/config.go
@@ -49,8 +49,8 @@ func SetConfigAtPath(configPath string) {
 	}
 }
 
-func GetFCFSSeqID() string {
-	return viper.GetString("device.fcfs_id")
+func GetFSCSID() string {
+	return viper.GetString("device.fscs_id")
 }
 
 func GetDeviceTag() string {
@@ -66,8 +66,8 @@ func GetAPIKey() string {
 	return viper.GetString("device.api_key")
 }
 
-func SetFCFSSeqID(id string) {
-	viper.Set("device.fcfs_id", id)
+func SetFSCSID(id string) {
+	viper.Set("device.fscs_id", id)
 }
 
 func SetDeviceTag(tag string) {
@@ -150,7 +150,7 @@ func SetConfigDefaults() {
 	// these must be filled in by the user. NB: these settings will _not_ be
 	// present in the config and are set here for explicitness.
 	viper.SetDefault("device.api_key", "")
-	viper.SetDefault("device.fcfs_id", "")
+	viper.SetDefault("device.fscs_id", "")
 	viper.SetDefault("device.tag", "")
 	// defaults for running in production
 	viper.SetDefault("config.minimum_minutes", 5)

--- a/imls-windows-installer/setup.iss
+++ b/imls-windows-installer/setup.iss
@@ -157,6 +157,6 @@ end;
 procedure WriteOutIni();
 begin
   SetIniString('user', 'api_key', LibraryPage.Values[0], ExpandConstant(CurrentFileName));
-  SetIniString('user', 'fcfs_id', LibraryPage.Values[1], ExpandConstant(CurrentFileName));
+  SetIniString('user', 'fscs_id', LibraryPage.Values[1], ExpandConstant(CurrentFileName));
   SetIniString('user', 'device_tag', DevicePage.Values[0], ExpandConstant(CurrentFileName));
 end;


### PR DESCRIPTION
Partially addresses #130:

- Rename FCFS to FSCS (Federal State Cooperative System)
- Rename Duration json fields to `start_time` and `end_time`
- Rename PiSerial to `Serial` (since we now support Windows)

We'll properly shape the API request in the next PR. 