### PR TITLE
Swap the reason and request fields in the form

### DIFF
--- a/.github/ISSUE_TEMPLATE/user-story-form.yml
+++ b/.github/ISSUE_TEMPLATE/user-story-form.yml
@@ -58,7 +58,7 @@ body:
     validations:
       required: true
 
-- type: markdown
+  - type: markdown
     attributes:
       value: |
         ## Optional fields

--- a/.github/ISSUE_TEMPLATE/user-story-form.yml
+++ b/.github/ISSUE_TEMPLATE/user-story-form.yml
@@ -42,14 +42,6 @@ body:
     validations:
       required: true
   - type: input
-    id: request
-    attributes:
-      label: Request
-      description: "Next, a user story includes the request; note: here we share what we want, not how we want it done"
-      placeholder: "(what) I want..."
-    validations:
-      required: true
-  - type: input
     id: reason
     attributes:
       label: Reason / Justification
@@ -57,7 +49,16 @@ body:
       placeholder: "(why) so that...."
     validations:
       required: true
-  - type: markdown
+  - type: input
+    id: request
+    attributes:
+      label: Request
+      description: "Next, a user story includes the request; note: here we share what we want, not how we want it done"
+      placeholder: "(what) I want..."
+    validations:
+      required: true
+
+- type: markdown
     attributes:
       value: |
         ## Optional fields

--- a/.github/ISSUE_TEMPLATE/user-story-form.yml
+++ b/.github/ISSUE_TEMPLATE/user-story-form.yml
@@ -1,7 +1,7 @@
 ---
 name: User Story
 description: Use this form to create a new user story
-labels: ["story"]
+labels: ["story", "needs refinement"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Per our conversation with @sknep and @jreme100 in the cowork chat today (Tuesday, August 16th), this PR swaps the reason and request fields (instead of "`As a _, so that _, I want _`" it now reads "`As a _, I want _, so that _`").  It also auto-adds the "needs refinement" label to newly-created issues.