### PR TITLE
windows: tweak dev scripts

### DIFF
--- a/imls-raspberry-pi/go.mod
+++ b/imls-raspberry-pi/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/viper v1.13.0
 	github.com/stretchr/testify v1.8.0
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
+	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10
 )
 
 require (

--- a/imls-raspberry-pi/go.sum
+++ b/imls-raspberry-pi/go.sum
@@ -282,6 +282,8 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2 h1:NWy5+hlRbC7HK+PmcXVUmW1IMyFce7to56IUvhUFm7Y=
 golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220906165146-f3363e06e74c h1:yKufUcDwucU5urd+50/Opbt4AYpqthk7wHpHok8f1lo=
+golang.org/x/net v0.0.0-20220906165146-f3363e06e74c/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -341,6 +343,8 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 h1:WIoqL4EROvwiPdUtaip4VcDdpZ4kha7wBWZrbVKCIZg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/imls-windows-installer/Makefile
+++ b/imls-windows-installer/Makefile
@@ -2,5 +2,5 @@
 
 all:
 	cp ~/go/bin/session-counter.exe release/
-	cp ~/go/bin/wifi-hardware-search-windows release/
+	cp ~/go/bin/wifi-hardware-search-windows.exe release/
 	"c:\Program Files (x86)\Inno Setup 6\ISCC.exe" setup.iss

--- a/imls-windows-installer/build_session-counter.ps1
+++ b/imls-windows-installer/build_session-counter.ps1
@@ -15,7 +15,9 @@ Set-Location ..
 # -- Build the exe
 Set-Location imls-raspberry-pi\cmd\session-counter
 Write-Host "Building session-counter executable."
-go build session-counter.go
+# call the Go executable directly since we might have just installed Go and it
+# may not be in our Path yet
+& 'C:\Program Files\Go\bin\go.exe' build session-counter.go
 $wd = Get-Location
 $exe_path = "$wd\session-counter.exe"
 

--- a/imls-windows-installer/build_wifi-hw-search.ps1
+++ b/imls-windows-installer/build_wifi-hw-search.ps1
@@ -15,7 +15,9 @@ Set-Location ..
 # -- Build the exe
 Set-Location imls-raspberry-pi\cmd\wifi-hardware-search-windows
 Write-Host "Building wifi-hardware-search executable."
-go build
+# call the Go executable directly since we might have just installed Go and it
+# may not be in our Path yet
+& 'C:\Program Files\Go\bin\go.exe' build
 $wd = Get-Location
 $exe_path = "$wd\wifi-hardware-search-windows.exe"
 


### PR DESCRIPTION
- Updates the dependencies (`go mod tidy`)
- Call out to go.exe explicitly instead of assuming it is in our Path (which might not be refreshed immediately)