### PR TITLE
backend/windows: minor tweaks

### DIFF
--- a/imls-backend/docker-compose.yml
+++ b/imls-backend/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       #In production this role should not be the same as the one used for the connection
       PGRST_DB_ANON_ROLE: web_anon
       PGRST_OPENAPI_SERVER_PROXY_URI: http://127.0.0.1:3000
-      PGRST_JWT_SECRET: "<fill_secret_key>"
+      PGRST_JWT_SECRET: "${POSTGREST_JWT_SECRET:-supersekr1t}"
     depends_on:
       - db
   db:

--- a/imls-windows-installer/.gitignore
+++ b/imls-windows-installer/.gitignore
@@ -1,1 +1,3 @@
-/Output
+session-counter.exe
+wifi-hardware-search-windows.exe
+Output/

--- a/imls-windows-installer/Makefile
+++ b/imls-windows-installer/Makefile
@@ -1,6 +1,0 @@
-.PHONY: all clean test
-
-all:
-	cp ~/go/bin/session-counter.exe release/
-	cp ~/go/bin/wifi-hardware-search-windows.exe release/
-	"c:\Program Files (x86)\Inno Setup 6\ISCC.exe" setup.iss

--- a/imls-windows-installer/check_nssm.ps1
+++ b/imls-windows-installer/check_nssm.ps1
@@ -1,0 +1,2 @@
+# nssm list is only available in unreleased versions
+Get-WmiObject win32_service | ?{$_.PathName -like '*nssm*'} | select Name, DisplayName, State, PathName

--- a/imls-windows-installer/setup.iss
+++ b/imls-windows-installer/setup.iss
@@ -3,6 +3,7 @@
 #define MyAppPublisher "GSA 10x"
 #define MyAppURL "https://github.com/IMLS/estimating-wifi"
 #define MyAppExeName "session-counter.exe"
+#define MySecondaryAppExeName "wifi-hardware-search-windows.exe"
 
 [Setup]
 AppId={{8D2CDEA5-9C55-44D4-84B3-ACDE9D4035BD}
@@ -31,7 +32,10 @@ Name: "{app}\service"
 [Files]
 ; NOTE: Do not use "Flags: ignoreversion" on any shared system files
 ; Our IMLS installer
-Source: ".\release\{#MyAppExeName}"; \
+Source: "{#MyAppExeName}"; \
+  DestDir: "{app}"; \
+  Flags: ignoreversion
+Source: "{#MySecondaryAppExeName}"; \
   DestDir: "{app}"; \
   Flags: ignoreversion
 Source: "README.txt"; \
@@ -62,12 +66,17 @@ Filename: "{app}\Wireshark\npcap-1.60.exe"; \
   Flags: runascurrentuser
 Filename: "{app}\service\nssm.exe"; \
   WorkingDir: "{app}"; \
-  Parameters: "install estimating-wifi ""{app}\session-counter.exe"" \
-    Application ""{app}\session-counter.exe"" \
+  Parameters: "install estimating-wifi ""{app}\{#MyAppExeName}"" \
+    Application ""{app}\{#MyAppExeName}"" \
     AppDirectory ""{app}"" \
     DisplayName ""IMLS Session Counter"" \
     Start SERVICE_AUTO_START"; \
-  Description: "nssm 2.24"; \
+  Description: "nssm 2.24 configuration"; \
+  Flags: runascurrentuser
+Filename: "{app}\service\nssm.exe"; \
+  WorkingDir: "{app}"; \
+  Parameters: "start estimating-wifi"; \
+  Description: "nssm 2.24 startup"; \
   Flags: runascurrentuser
 
 [Code]

--- a/imls-windows-installer/setup.iss
+++ b/imls-windows-installer/setup.iss
@@ -64,6 +64,9 @@ Filename: "{app}\Wireshark\WiresharkPortable64_3.6.5.paf.exe"; \
 Filename: "{app}\Wireshark\npcap-1.60.exe"; \
   Description: "npcap 1.60"; \
   Flags: runascurrentuser
+Filename: "{app}\{#MySecondaryAppExeName}"; \
+  Description: "wifi-hardware-search-windows"
+  Flags: runascurrentuser
 Filename: "{app}\service\nssm.exe"; \
   WorkingDir: "{app}"; \
   Parameters: "install estimating-wifi ""{app}\{#MyAppExeName}"" \


### PR DESCRIPTION
- Adds a localhost-only default for `PGRST_JWT_SECRET`
- Adds a way to check if nssm script is running (this should be built in nssm itself, but alas)
- Modifies setup.iss to actually start session-counter. (Note: s-c still crashes in a loop at this time)