### PR TITLE
Search bugfix

### DIFF
--- a/imls-wifi-sensor/cmd/wifi-hardware-search-cli/find-ralink.go
+++ b/imls-wifi-sensor/cmd/wifi-hardware-search-cli/find-ralink.go
@@ -43,8 +43,7 @@ func launch() {
 		log.Warn().Msg("wifi-hardware-search-cli needs to be run as root.")
 	}
 
-	device := new(models.Device)
-	device.Extract = extract
+	var device *models.Device
 
 	// If either --field or --search are used, then we need to do two things
 	//  1. disable --discovery
@@ -61,29 +60,11 @@ func launch() {
 
 	// If we ask for auto-discovery, try it and exit.
 	if discover {
-		// We either have searches in /etc, or a few held in reserve
-		// that are compiled in via `embed`. GetSearches pulls the "live"
-		// searches if it can, and falls back to the embedded if needed.
-		// It goes through each one-by-one.
-		for _, s := range search.GetSearches() {
-			log.Debug().
-				Str("field", s.Field).
-				Str("query", s.Query).
-				Msg("searching")
-			device.Search = &s
-			// FindMatchingDevice populates device.Exists if something is found.
-			search.FindMatchingDevice(device)
-			// We can stop searching if we find something.
-			if device.Exists {
-				break
-			}
-		}
+		device = search.SearchForMatchingDevice()
 	} else {
 		// The alternative is we're not doing an exhaustive/discovery search.
 		// Therefore, we should use the field/search params
-		s := &models.Search{Field: lshwField, Query: lshwSearch}
-		device.Search = s
-		search.FindMatchingDevice(device)
+		device = search.SearchForMatchingDeviceWithQuery(lshwField, lshwSearch)
 	}
 
 	// If we asked for a true/false value, print that.

--- a/imls-wifi-sensor/cmd/wifi-hardware-search-windows/find-device.go
+++ b/imls-wifi-sensor/cmd/wifi-hardware-search-windows/find-device.go
@@ -5,14 +5,11 @@ import (
 	"fmt"
 
 	"golang.org/x/sys/windows"
-	"gsa.gov/18f/internal/wifi-hardware-search/models"
 	"gsa.gov/18f/internal/wifi-hardware-search/search"
 )
 
 func main() {
-	device := new(models.Device)
-	device.Exists = false
-	search.FindMatchingDevice(device)
+	device := search.SearchForMatchingDevice()
 	title := windows.StringToUTF16Ptr("IMLS: compatible wifi device query")
 	if device.Exists {
 		message := windows.StringToUTF16Ptr(fmt.Sprintf("found a compatible wifi device: %s (%s) [%s]",

--- a/imls-wifi-sensor/internal/wifi-hardware-search/models/device.go
+++ b/imls-wifi-sensor/internal/wifi-hardware-search/models/device.go
@@ -19,5 +19,4 @@ type Device struct {
 	Mac           string
 	Configuration string
 	Vendor        string
-	Extract       string
 }

--- a/imls-wifi-sensor/internal/wifi-hardware-search/search/search.go
+++ b/imls-wifi-sensor/internal/wifi-hardware-search/search/search.go
@@ -82,11 +82,20 @@ func SearchForMatchingDevice() *models.Device {
 	for _, s := range GetSearches() {
 		dev.Search = &s
 		// findMatchingDevice populates device. Exits if something is found.
-		FindMatchingDevice(dev)
+		findMatchingDevice(dev)
 		if dev.Exists {
 			break
 		}
 	}
+	return dev
+}
+
+func SearchForMatchingDeviceWithQuery(field string, query string) *models.Device {
+	dev := new(models.Device)
+	dev.Exists = false
+	s := &models.Search{Field: field, Query: query}
+	dev.Search = s
+	findMatchingDevice(dev)
 	return dev
 }
 
@@ -102,7 +111,7 @@ func osFindMatchingDevice(wlan *models.Device) []map[string]string {
 // PURPOSE
 // Takes a Device structure and, using the Search fields of that structure,
 // attempts to find a matching WLAN device.
-func FindMatchingDevice(wlan *models.Device) {
+func findMatchingDevice(wlan *models.Device) {
 	devices := osFindMatchingDevice(wlan)
 
 	// We start by assuming that we have not found the device.


### PR DESCRIPTION
We need to make sure the `models.Search` parameter is always populated, and currently it's fairly easy to invoke UB by doing the wrong thing. Fixed on both windows and linux.

--

Regarding this crash: we have the following go models:

```go
type Search struct {
	Field string `json:"field"`
	Query string `json:"query"`
}

type Device struct {
	Exists        bool
	Search        *Search
	Physicalid    int
	Description   string
	Businfo       string
	Logicalname   string
	Serial        string
	Mac           string
	Configuration string
	Vendor        string
}
```

note that `Search` is a pointer in `Device`. we often initialize `Device` by doing `new(Device)` but `Search` is set to nil. (we have to call `GetSearches` somewhere to populate `Search`). so far so good.

but if the above call doesn't happen in time, we'll hit device.Search.Field as ([here](https://github.com/IMLS/estimating-wifi/blob/d1af24a7338c0d44baaa040451b6fcded3ef155e/imls-wifi-sensor/internal/wifi-hardware-search/search/search.go#L119)) and then :boom: since it's an uninitialized memory reference.