### PR TITLE
windows end-to-end documentation

### DIFF
--- a/imls-wifi-sensor/Makefile
+++ b/imls-wifi-sensor/Makefile
@@ -22,7 +22,7 @@ deps:
 	go mod download
 
 session-counter: deps
-	${ENVVARS} go install -ldflags $(LDFLAGS) gsa.gov/18f/cmd/session-counter
+	${ENVVARS} go install -ldflags $(LDFLAGS) gsa.gov/18f/cmd/linux-session-counter
 
 wifi-hardware-search-cli: deps
 	${ENVVARS} go install -ldflags $(LDFLAGS) gsa.gov/18f/cmd/wifi-hardware-search-cli

--- a/imls-windows-installer/README.md
+++ b/imls-windows-installer/README.md
@@ -57,7 +57,7 @@ This process assumes a user is using a Windows machine, has admin rights, has do
 
 To run end-to-end tests on Windows requires WSL2. The basic idea is to run the backend in a Linux VM and have the Windows service "talk" to this backend. Steps:
 
-- Install WSL2 and your favorite Linux distribution. 
+- Install WSL2 and your favorite Linux distribution.
   - Ubuntu has a good guide on [how to install Ubuntu on WSL2](https://ubuntu.com/tutorials/install-ubuntu-on-wsl2-on-windows-10#1-overview).
 - In Ubuntu, install the tools necessary to run Docker. `sudo apt-get -y install docker-compose docker.io`
   - You might need to run `sudo apt-get update` beforehand.
@@ -67,7 +67,7 @@ To run end-to-end tests on Windows requires WSL2. The basic idea is to run the b
   - Open up a separate Ubuntu terminal
   - Clone this repository
   - Change directory to the `imls-backend` directory
-  - Run `DOCKER_HOST=unix:///var/run/docker.sock docker-compose up` 
+  - Run `DOCKER_HOST=unix:///var/run/docker.sock docker-compose up`
     - Please note, if this command fails as a normal user, you can add your user to the group `sudo usermod -aG docker $USER` or you can just `sudo` this command.
 - You probably also want to run migrations. Unfortunately, `dbmate` is not easily installable on Ubuntu, so we'll download the binary ourselves.
   - Open up a separate (third!) Ubuntu terminal
@@ -75,7 +75,7 @@ To run end-to-end tests on Windows requires WSL2. The basic idea is to run the b
   - `sudo chown +x dbmate`
   - `./dbmate up`
 - To verify that all is running correctly:
-  - Open up a separate Powershell terminal and run `curl.exe -v 127.0.0.1:300/presences` 
+  - Open up a separate Powershell terminal and run `curl.exe -v 127.0.0.1:300/presences`
 - Install the Windows session-counter service as normal, if you haven't already.
 - Edit your session-counter.ini:
   - Under `[api]`, you should have: `host=127.0.0.1:3000`

--- a/imls-windows-installer/README.md
+++ b/imls-windows-installer/README.md
@@ -52,3 +52,31 @@ This process assumes a user is using a Windows machine, has admin rights, has do
 - Ctrl + Alt + Delete to open the Task Manager
 - Scroll to the Background Processes section
 - If `Windows Service Wrapper` is running the `estimating-wifi` program, then it's running in the background as expected
+
+# Full stack testing
+
+To run end-to-end tests on Windows requires WSL2. The basic idea is to run the backend in a Linux VM and have the Windows service "talk" to this backend. Steps:
+
+- Install WSL2 and your favorite Linux distribution. 
+  - Ubuntu has a good guide on [how to install Ubuntu on WSL2](https://ubuntu.com/tutorials/install-ubuntu-on-wsl2-on-windows-10#1-overview).
+- In Ubuntu, install the tools necessary to run Docker. `sudo apt-get -y install docker-compose docker.io`
+  - You might need to run `sudo apt-get update` beforehand.
+- Running Docker in Ubuntu in WSL can be clunky. We'll have to start the service manually because systemd is not available (although this has [changed recently](https://devblogs.microsoft.com/commandline/systemd-support-is-now-available-in-wsl/)):
+  - `sudo dockerd`
+- Now we can build the backend.
+  - Open up a separate Ubuntu terminal
+  - Clone this repository
+  - Change directory to the `imls-backend` directory
+  - Run `DOCKER_HOST=unix:///var/run/docker.sock docker-compose up` 
+    - Please note, if this command fails as a normal user, you can add your user to the group `sudo usermod -aG docker $USER` or you can just `sudo` this command.
+- You probably also want to run migrations. Unfortunately, `dbmate` is not easily installable on Ubuntu, so we'll download the binary ourselves.
+  - Open up a separate (third!) Ubuntu terminal
+  - `sudo curl -fsSL -o dbmate https://github.com/amacneil/dbmate/releases/latest/download/dbmate-linux-amd64`
+  - `sudo chown +x dbmate`
+  - `./dbmate up`
+- To verify that all is running correctly:
+  - Open up a separate Powershell terminal and run `curl.exe -v 127.0.0.1:300/presences` 
+- Install the Windows session-counter service as normal, if you haven't already.
+- Edit your session-counter.ini:
+  - Under `[api]`, you should have: `host=127.0.0.1:3000`
+  - Restart session-counter by running `WinSw-x64.exe restart` in the installed IMLS Session Counter directory.


### PR DESCRIPTION
Adds documentation on how to run end-to-end tests on windows. Admittedly this process could be made easier, especially if we pull in `dbmate` usage in the container. Also systemd on windows is a Thing Now. But, in the interests of expediency, here's what worked for me.

Also threw in a quick bug fix for the Makefile.