### PR TITLE
Un-fakified the preload data.

### DIFF
--- a/imls-backend/init/.gitignore
+++ b/imls-backend/init/.gitignore
@@ -1,0 +1,1 @@
+20-test-data.sql

--- a/imls-backend/init/README.md
+++ b/imls-backend/init/README.md
@@ -2,12 +2,20 @@
 
 For local development, we have multiple data files.
 
-`test-data.sql.gz` contains *real* data that is anonymized. It is pulled from the Phase 3 data collection, and then updated to match the current data schema.
+`test-data.sql.gz` contains *real* data that is anonymized. It is pulled from the Phase 3 data collection, and then updated to match the current data schema. The library ids in this data are *real*, but they are not associated with actual data. For example: the library `CA0001-001` is a real library, but the data associated with it is from random data previously collected.
 
 `imls-data-2020.csv` is data from the Institute of Museum and Library Services (IMLS). Specifically, we are using outlet data from 2020. It is public domain data, and we sourced it from <https://www.imls.gov/research-evaluation/data-collection/public-libraries-survey>.
 
 The IMLS data file is loaded via `\copy`, and therefore we need both an `.sql` file and the `.csv`; the `.sql` file defines the table, and then uses the Postgres-specific `\copy` command to load the CSV file into that table. 
 
+## Library ids in fakified data
+
+* CA0001-001
+* KY0069-002
+* ME0119-001
+* TX0111-001
+* GA0027-001
+* GA0058-001
 # To use this data
 
 You will need to:


### PR DESCRIPTION
This changes the libraries from made-up FCFS ids (AA000x-001) to *real* library ids.

The library IDs chosen are for real libraries, but the data in the file does *not* correspond to the libraries indicated. We have done this so that we can test interface elements that require lookups using real FCFS library ids.