### PR TITLE
Make library page use 'yesterday' by default unless .env provides an override

### DIFF
--- a/imls-frontend/README.md
+++ b/imls-frontend/README.md
@@ -26,6 +26,12 @@ You should add a .env file for local development, which will provide the app wit
 VITE_BACKEND_BASEURL=http://localhost:3000
 ```
 
+If have loaded the [sample data](../imls-backend/README.md) via the "setup-for-tests.sh" script in your backend docker container (see the "Optional: Loading test data" section), you may provide a default date override via env variable so that the Library page loads at the most recent date where we have sample data. For now, we have sample data for the month of May 2022:
+
+```
+VITE_DEFAULT_DATE_OVERRIDE=2022-05-31
+```
+
 ### Compile and Hot-Reload for Development
 
 ```sh

--- a/imls-frontend/src/assets/index.scss
+++ b/imls-frontend/src/assets/index.scss
@@ -29,3 +29,7 @@
     @include u-bg('blue-warm-10');
   }
 }
+
+.maxw-date-picker{
+  max-width: 20em;
+}

--- a/imls-frontend/src/components/USWDSDatePicker.vue
+++ b/imls-frontend/src/components/USWDSDatePicker.vue
@@ -1,11 +1,9 @@
 <script>
 import datePicker from "uswds/src/js/components/date-picker";
+import { startOfYesterday } from "date-fns";
 
-// artificially limits selectable dates to the time we have 
-// deterministic placeholder data for. 
-// todo: refactor when we're using actual data
-const MIN_DATE = "2022-05-01";
-const MAX_DATE = "2022-05-31";
+const MIN_DATE = "2022-01-01";
+const MAX_DATE = startOfYesterday().toISOString().split("T")[0];
 
 export default {
   name: "USWDSDatePicker",
@@ -52,7 +50,7 @@ export default {
     <div id="date-hint" class="usa-hint">mm/dd/yyyy</div>
     <div
 ref="picker" 
-      class="usa-date-picker maxw-card-lg" 
+      class="usa-date-picker maxw-date-picker" 
       :data-default-value="initialDate"
       :data-selected-date="!!selectedDate ? selectedDate : initialDate"
       :data-min-date="minDate"

--- a/imls-frontend/src/views/PageLibrary.spec.js
+++ b/imls-frontend/src/views/PageLibrary.spec.js
@@ -1,9 +1,11 @@
 import { mount, shallowMount, flushPromises } from "@vue/test-utils";
-import { expect } from "vitest";
+import { expect, vi } from "vitest";
 import PageLibrary from "./PageLibrary.vue";
 import { createRouter, createWebHistory } from "vue-router";
 import { routes } from "../router/index.js";
-import { startOfMonth } from "date-fns";
+import { startOfYesterday } from "date-fns";
+import { loadEnv } from 'vite';
+
 
 let router;
 
@@ -44,7 +46,7 @@ beforeEach(async () => {
 });
 
 describe("PageLibrary", () => {
-  it("should render with May first data if no date is provided", () => {
+  it("should load at yesterday's date when no date is provided", () => {
     const wrapper = mount(PageLibrary, {
       props: {
         id: "KnownGoodId",
@@ -68,10 +70,11 @@ describe("PageLibrary", () => {
     
     expect(wrapper.find("h1").text()).toEqual("Library KnownGoodId");
     expect(wrapper.findAll(".usa-card").length).toBeGreaterThanOrEqual(1);
-    expect(wrapper.vm.activeDate).toEqual(
-      startOfMonth(new Date(2022, 4)).toISOString().split("T")[0]
+    expect(wrapper.vm.selectedDateUTC).toEqual(
+       startOfYesterday()
     );
   });
+
 
   it("should render with a preset date if one is provided", () => {
     const wrapper = shallowMount(PageLibrary, {
@@ -83,20 +86,53 @@ describe("PageLibrary", () => {
         stubs: ["router-link", "router-view", "RouterView", "RouterLink"],
       },
     });
-    expect(wrapper.vm.activeDate).toEqual("2022-05-02");
+    expect(PageLibrary.methods.toISODate(wrapper.vm.selectedDateUTC)).toEqual("2022-05-02");
+    
   });
 
   it("should format day labels for n days given a date and count", () => {
     expect(
-      PageLibrary.methods.generateDayLabels("1999-12-31", 3)
+      PageLibrary.methods.generateDayLabels( new Date("1999-12-31T00:00"), 3)
     ).toStrictEqual(["12/31/99", "1/1/00", "1/2/00"]);
   });
-  
-  it("should return the first day of the week in ISO", () => {
-    expect(
-      PageLibrary.computed.startOfWeekInISO.call({ selectedDate: "1999-12-31" })
-    ).toBe("1999-12-26");
+
+
+  describe("should compute the start and end times for each graph on the library page", () => {
+    const wrapper = mount(PageLibrary, {
+      props: {
+        id: "KnownGoodId",
+        selectedDate: "1999-12-31"
+      },
+      global: {
+        stubs: [
+          "router-link",
+          "router-view",
+          "RouterView",
+          "RouterLink",
+          "USWDSDatePicker",
+          "USWDSCard",
+          "FetchData",
+          "Histogram",
+          "Heatmap",
+          "HeatmapWeeklyCalendar",
+          "USWDSTable",
+        ],
+      },
+    });
+      // TODO: TEST ALL THE NEW COMPUTEDS
+    it("should return the first day of the current week", () => {
+      expect(wrapper.vm.startOfCurrentWeekUTC).toStrictEqual(new Date("1999-12-26T00:00"))
+    });
+    it("should return the last day of the current week", () => {
+      expect(wrapper.vm.endOfCurrentWeekUTC).toStrictEqual(new Date("2000-01-02T00:00"))
+    });
+    it("should return the date six days ago", () => {
+      expect(wrapper.vm.sixDaysAgoUTC).toStrictEqual(new Date("1999-12-25T00:00"))
+    });
+
   });
+
+
 
   it("should respond by navigating to a new route query param when the selected date changes", async () => {
     const spyChangeDate = vi.spyOn(

--- a/imls-frontend/src/views/PageLibrary.spec.js
+++ b/imls-frontend/src/views/PageLibrary.spec.js
@@ -4,7 +4,6 @@ import PageLibrary from "./PageLibrary.vue";
 import { createRouter, createWebHistory } from "vue-router";
 import { routes } from "../router/index.js";
 import { startOfYesterday } from "date-fns";
-import { loadEnv } from 'vite';
 
 
 let router;

--- a/imls-frontend/test/setup.js
+++ b/imls-frontend/test/setup.js
@@ -1,4 +1,3 @@
-//setupVitest.js or similar file
 import createFetchMock from 'vitest-fetch-mock';
 import { vi } from 'vitest';
 


### PR DESCRIPTION
Closes #329 and prepares the frontend for end-to-end testing.

Removes the guard on either side of May 2022 that limits the library page from selecting other dates. The default start date for backend data is now "yesterday", so we can see recently posted presence data on first load on production.

For future development:

If a default start date is provided to the front end via .env variable (`VITE_DEFAULT_DATE_OVERRIDE=2022-05-31`), the Library page will load at that start date on first visit (so we can continue to test using May 2022 data without always scrolling through 6 months of the date picker). It's just for developer quality of life/testing.