### PR TITLE
fix up defaults and .ini file

### DIFF
--- a/imls-wifi-sensor/internal/config/config.go
+++ b/imls-wifi-sensor/internal/config/config.go
@@ -100,7 +100,7 @@ func createURI(what string) string {
 	fullURI := (scheme + "://" +
 		strings.TrimSuffix(strings.TrimPrefix(host, "/"), "/") +
 		":" + fmt.Sprint(port) + "/" +
-		strings.TrimPrefix(api_uri, "/")) + "/" +
+		strings.TrimPrefix(api_uri, "/") + "/" +
 		strings.TrimPrefix(what, "/"))
 	log.Info().Msg("FULL URI: " + fullURI)
 	return (fullURI)

--- a/imls-wifi-sensor/internal/config/config.go
+++ b/imls-wifi-sensor/internal/config/config.go
@@ -102,7 +102,7 @@ func createURI(what string) string {
 		":" + fmt.Sprint(port) + "/" +
 		strings.TrimPrefix(api_uri, "/") + "/" +
 		strings.TrimPrefix(what, "/"))
-	log.Info().Msg("FULL URI: " + fullURI)
+	log.Debug().Msg("createURI(): " + fullURI)
 	return (fullURI)
 }
 

--- a/imls-wifi-sensor/internal/config/config.go
+++ b/imls-wifi-sensor/internal/config/config.go
@@ -96,10 +96,12 @@ func createURI(what string) string {
 	scheme := viper.GetString("api.scheme")
 	host := viper.GetString("api.host")
 	port := viper.GetInt("api.port")
-	return (scheme + "://" +
+	fullURI = (scheme + "://" +
 		strings.TrimSuffix(strings.TrimPrefix(host, "/"), "/") +
 		":" + fmt.Sprint(port) + "/" +
 		strings.TrimPrefix(what, "/"))
+		log.Info().Msg("FULL URI: " + fullURI)
+	return (fullURI)
 }
 
 func GetDurationsURI() string {

--- a/imls-wifi-sensor/internal/config/config.go
+++ b/imls-wifi-sensor/internal/config/config.go
@@ -96,7 +96,7 @@ func createURI(what string) string {
 	scheme := viper.GetString("api.scheme")
 	host := viper.GetString("api.host")
 	port := viper.GetInt("api.port")
-	fullURI = (scheme + "://" +
+	fullURI := (scheme + "://" +
 		strings.TrimSuffix(strings.TrimPrefix(host, "/"), "/") +
 		":" + fmt.Sprint(port) + "/" +
 		strings.TrimPrefix(what, "/"))

--- a/imls-wifi-sensor/internal/config/config.go
+++ b/imls-wifi-sensor/internal/config/config.go
@@ -100,7 +100,7 @@ func createURI(what string) string {
 		strings.TrimSuffix(strings.TrimPrefix(host, "/"), "/") +
 		":" + fmt.Sprint(port) + "/" +
 		strings.TrimPrefix(what, "/"))
-		log.Info().Msg("FULL URI: " + fullURI)
+	log.Info().Msg("FULL URI: " + fullURI)
 	return (fullURI)
 }
 

--- a/imls-wifi-sensor/internal/config/config.go
+++ b/imls-wifi-sensor/internal/config/config.go
@@ -96,9 +96,11 @@ func createURI(what string) string {
 	scheme := viper.GetString("api.scheme")
 	host := viper.GetString("api.host")
 	port := viper.GetInt("api.port")
+	api_uri := viper.GetString("api.api_uri")
 	fullURI := (scheme + "://" +
 		strings.TrimSuffix(strings.TrimPrefix(host, "/"), "/") +
 		":" + fmt.Sprint(port) + "/" +
+		strings.TrimPrefix(api_uri, "/")) + "/" +
 		strings.TrimPrefix(what, "/"))
 	log.Info().Msg("FULL URI: " + fullURI)
 	return (fullURI)
@@ -209,9 +211,10 @@ func SetConfigDefaults() {
 	viper.SetDefault("log.level", "DEBUG")
 	viper.SetDefault("log.loggers", "local:stderr,local:tmp")
 	viper.SetDefault("mode.run", "prod")
-	viper.SetDefault("api.scheme", "https")
-	viper.SetDefault("api.host", "rabbit-phase-4.app.cloud.gov")
-	viper.SetDefault("api.port", 443)
+	viper.SetDefault("api.scheme", "http")
+	viper.SetDefault("api.host", "localhost")
+	viper.SetDefault("api.port", 80)
+	viper.SetDefault("api.api_uri", "")
 	viper.SetDefault("api.login_uri", "/rpc/login")
 	viper.SetDefault("api.heartbeat_uri", "/rpc/beat_the_heart")
 	viper.SetDefault("api.presences_uri", "/rpc/update_presence")

--- a/imls-wifi-sensor/internal/session-counter-helper/api/api.go
+++ b/imls-wifi-sensor/internal/session-counter-helper/api/api.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"time"
+	"strconv"
 
 	resty "github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog/log"
@@ -69,7 +70,7 @@ func PostAuthentication(jwt *JWTToken) error {
 }
 
 func PostDurations(durations []*state.Duration) error {
-	log.Debug().Msg("PostDurations(): Posting", Str( len(durations)), "durations...")
+	log.Debug().Msg("PostDurations(): Posting", strconv.Itoa(len(durations)), "durations...")
 	token := JWTToken{}
 	auth_err := PostAuthentication(&token)
 	if auth_err != nil {

--- a/imls-wifi-sensor/internal/session-counter-helper/api/api.go
+++ b/imls-wifi-sensor/internal/session-counter-helper/api/api.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"time"
-	"fmt"
 	"strconv"
 
 	resty "github.com/go-resty/resty/v2"
@@ -71,9 +70,7 @@ func PostAuthentication(jwt *JWTToken) error {
 }
 
 func PostDurations(durations []*state.Duration) error {
-	log.Debug().Msg(fmt.Println("PostDurations(): Posting",
-				    strconv.Itoa(len(durations)),
-				    "durations..."))
+	log.Debug().Msg("PostDurations(): Posting" + strconv.Itoa(len(durations)) + "durations...")
 	token := JWTToken{}
 	auth_err := PostAuthentication(&token)
 	if auth_err != nil {

--- a/imls-wifi-sensor/internal/session-counter-helper/api/api.go
+++ b/imls-wifi-sensor/internal/session-counter-helper/api/api.go
@@ -70,7 +70,7 @@ func PostAuthentication(jwt *JWTToken) error {
 }
 
 func PostDurations(durations []*state.Duration) error {
-	log.Debug().Msg("PostDurations(): Posting" + strconv.Itoa(len(durations)) + "durations...")
+	log.Debug().Msg("PostDurations(): Posting " + strconv.Itoa(len(durations)) + " durations...")
 	token := JWTToken{}
 	auth_err := PostAuthentication(&token)
 	if auth_err != nil {

--- a/imls-wifi-sensor/internal/session-counter-helper/api/api.go
+++ b/imls-wifi-sensor/internal/session-counter-helper/api/api.go
@@ -69,6 +69,7 @@ func PostAuthentication(jwt *JWTToken) error {
 }
 
 func PostDurations(durations []*state.Duration) error {
+	log.Debug().Msg("PostDurations(): Posting", Str( len(durations)), "durations...")
 	token := JWTToken{}
 	auth_err := PostAuthentication(&token)
 	if auth_err != nil {
@@ -106,6 +107,7 @@ func PostDurations(durations []*state.Duration) error {
 			return err
 		}
 	}
+	log.Debug().Msg("Posting complete")
 
 	return nil
 }

--- a/imls-wifi-sensor/internal/session-counter-helper/api/api.go
+++ b/imls-wifi-sensor/internal/session-counter-helper/api/api.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"time"
+	"fmt"
 	"strconv"
 
 	resty "github.com/go-resty/resty/v2"
@@ -70,7 +71,9 @@ func PostAuthentication(jwt *JWTToken) error {
 }
 
 func PostDurations(durations []*state.Duration) error {
-	log.Debug().Msg("PostDurations(): Posting", strconv.Itoa(len(durations)), "durations...")
+	log.Debug().Msg(fmt.printLn("PostDurations(): Posting",
+				    strconv.Itoa(len(durations)),
+				    "durations..."))
 	token := JWTToken{}
 	auth_err := PostAuthentication(&token)
 	if auth_err != nil {

--- a/imls-wifi-sensor/internal/session-counter-helper/api/api.go
+++ b/imls-wifi-sensor/internal/session-counter-helper/api/api.go
@@ -71,7 +71,7 @@ func PostAuthentication(jwt *JWTToken) error {
 }
 
 func PostDurations(durations []*state.Duration) error {
-	log.Debug().Msg(fmt.printLn("PostDurations(): Posting",
+	log.Debug().Msg(fmt.Println("PostDurations(): Posting",
 				    strconv.Itoa(len(durations)),
 				    "durations..."))
 	token := JWTToken{}

--- a/imls-windows-installer/session-counter.ini
+++ b/imls-windows-installer/session-counter.ini
@@ -4,8 +4,9 @@
 host=statspilot.galibs.org
 scheme=https
 port=443
-presences_uri=/api/rpc/update_presence
-heartbeat_uri=/api/rpc/beat_the_heart
+api_uri=/api
+presences_uri=/rpc/update_presence
+heartbeat_uri=/rpc/beat_the_heart
 login_uri=/rpc/login
 
 [config]

--- a/imls-windows-installer/session-counter.ini
+++ b/imls-windows-installer/session-counter.ini
@@ -1,11 +1,11 @@
 [device]
 
 [api]
-host=statspilot.galibs.org/api
+host=statspilot.galibs.org
 scheme=https
 port=443
-presences_uri=/rpc/update_presence
-heartbeat_uri=/rpc/beat_the_heart
+presences_uri=/api/rpc/update_presence
+heartbeat_uri=/api/rpc/beat_the_heart
 login_uri=/rpc/login
 
 [config]


### PR DESCRIPTION
What I ended up going with was the following:
defaults in the Go code are going to be for `scheme = http` , `host = localhost`, `port = 80`, and  `api_uri = " "`
then the default `.ini` file will overwrite all of those with

```
[api]
host=statspilot.galibs.org
scheme=https
port=443
api_uri=/api
presences_uri=/rpc/update_presence
heartbeat_uri=/rpc/beat_the_heart
login_uri=/rpc/login
```

`api_uri` is new, it goes in between port and the other *_uri params. For our prod server, it's the endpoint `/api`

this would allow for you to setup for local backend by either removing the `[api]` section or re -configuring it as needed.
but default out-of-the-box install behavior will be for production use by end users, sending data to [statspilot.galibs.org](https://statspilot.galibs.org/) and the proper URI as specified in the .ini