### PR TITLE
Front end UI tweaks and a11y fixes 

### DIFF
--- a/imls-frontend/index.html
+++ b/imls-frontend/index.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Public Library Wifi Estimator</title>
-    <!-- TODO: dynamic page name and meta description -->
-  </head>
-  <body>
-    <div id="app"></div>
-    <script type="module" src="/src/main.js"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" href="/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/main.js"></script>
+</body>
+
 </html>

--- a/imls-frontend/package-lock.json
+++ b/imls-frontend/package-lock.json
@@ -25,6 +25,7 @@
         "vite": "^2.7.13",
         "vue": "^3.2.29",
         "vue-chartjs": "^4.1.1",
+        "vue-meta": "^3.0.0-alpha.10",
         "vue-router": "^4.0.12"
       },
       "devDependencies": {
@@ -2754,6 +2755,14 @@
         "eslint": ">=6.0.0"
       }
     },
+    "node_modules/vue-meta": {
+      "version": "3.0.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/vue-meta/-/vue-meta-3.0.0-alpha.10.tgz",
+      "integrity": "sha512-rYeIGkhm1gKBcReEkPHiV6LV2Y6BZTMGTkGw1mQIZTxfFcVJL0srLZsL1zAmLeTGxMrlDYylMQEVSYRkDnwz3A==",
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
     "node_modules/vue-router": {
       "version": "4.1.3",
       "license": "MIT",
@@ -4531,6 +4540,12 @@
         "lodash": "^4.17.21",
         "semver": "^7.3.5"
       }
+    },
+    "vue-meta": {
+      "version": "3.0.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/vue-meta/-/vue-meta-3.0.0-alpha.10.tgz",
+      "integrity": "sha512-rYeIGkhm1gKBcReEkPHiV6LV2Y6BZTMGTkGw1mQIZTxfFcVJL0srLZsL1zAmLeTGxMrlDYylMQEVSYRkDnwz3A==",
+      "requires": {}
     },
     "vue-router": {
       "version": "4.1.3",

--- a/imls-frontend/package.json
+++ b/imls-frontend/package.json
@@ -27,6 +27,7 @@
     "vite": "^2.7.13",
     "vue": "^3.2.29",
     "vue-chartjs": "^4.1.1",
+    "vue-meta": "^3.0.0-alpha.10",
     "vue-router": "^4.0.12"
   },
   "engines": {

--- a/imls-frontend/src/App.spec.js
+++ b/imls-frontend/src/App.spec.js
@@ -1,8 +1,12 @@
-import { mount } from "@vue/test-utils";
+import { mount, shallowMount } from "@vue/test-utils";
 import App from "./App.vue";
 import { routes } from "./router/index.js";
 import { createRouter, createWebHistory } from "vue-router";
+import { createMetaManager, plugin as vueMetaPlugin } from 'vue-meta'
+import { expect } from "vitest";
+
 let router;
+let vueMetaManager = createMetaManager(); 
 
 beforeEach(async () => {
   router = createRouter({
@@ -17,11 +21,20 @@ describe("App", () => {
   it("should render a Header and Footer", () => {
     const wrapper = mount(App, {
       global: {
-        plugins: [router],
+        plugins: [router, vueMetaManager, vueMetaPlugin],
       },
     });
-
     expect(wrapper.findAll(".usa-header")).toHaveLength(1);
     expect(wrapper.findAll(".usa-footer")).toHaveLength(1);
+  });
+
+  it("should provide default site metadata", () => {
+    const wrapper = shallowMount(App, {
+      global: {
+        plugins: [router, vueMetaManager, vueMetaPlugin],
+      },
+    });
+    expect(App.metaInfo).toHaveProperty("title")
+    expect(App.metaInfo).toHaveProperty("description")
   });
 });

--- a/imls-frontend/src/App.spec.js
+++ b/imls-frontend/src/App.spec.js
@@ -1,4 +1,4 @@
-import { mount, shallowMount } from "@vue/test-utils";
+import { mount, shallowMount, flushPromises } from "@vue/test-utils";
 import App from "./App.vue";
 import { routes } from "./router/index.js";
 import { createRouter, createWebHistory } from "vue-router";
@@ -36,5 +36,28 @@ describe("App", () => {
     });
     expect(App.metaInfo).toHaveProperty("title")
     expect(App.metaInfo).toHaveProperty("description")
+  });
+
+  it("should skip focus to the main element on route change", async () => {
+    const spyChangeFocus = vi.spyOn(
+      App.methods,
+      "setRouteWrapperFocus"
+    );
+
+    const wrapper = mount(App, {
+      global: {
+        plugins: [router, vueMetaManager, vueMetaPlugin],
+      },
+      attachTo: document.body
+    });
+    // hasn't skipped focus to main yet
+    expect(wrapper.vm.$refs.focus).not.toBe(document.activeElement);
+    expect(spyChangeFocus).toHaveBeenCalledTimes(0);
+    router.push("/");
+    // we're going to force this method to run because the watcher on $route change isn't running in the test env
+    wrapper.vm.setRouteWrapperFocus();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.$refs.focus).toBe(document.activeElement);
+    expect(spyChangeFocus).toHaveBeenCalledTimes(1);
   });
 });

--- a/imls-frontend/src/App.vue
+++ b/imls-frontend/src/App.vue
@@ -15,17 +15,17 @@ export default {
     title: "Welcome",
     description: "This tool is the result of a collaborative research project with the Institute of Museum and Library Services, the Georgia Public Library Service, and Technology Transformation Services' 10x program."
   },
+  watch: {
+    $route: function() {
+      this.setRouteWrapperFocus();
+    }
+  },
   methods:{
     setRouteWrapperFocus() {
       this.$nextTick(function() {
         this.$refs.focus.focus();
       });
     },
-  },
-  watch: {
-    $route: function() {
-      this.setRouteWrapperFocus();
-    }
   }
 };
 </script>
@@ -34,7 +34,7 @@ export default {
 
   <div>
     <metainfo>
-      <template v-slot:title="{ content }">{{ content }} | Public Library Wifi Estimator</template>
+      <template #title="{ content }">{{ content }} | Public Library Wifi Estimator</template>
     </metainfo>
     <USWDSHeader />
 
@@ -42,8 +42,8 @@ export default {
       <div class="grid-container">
         <div class="grid-row grid-gap">
           <main
-            ref="focus"
             id="main-content"
+            ref="focus"
             class="grid-col"
             tabindex="-1"
           >

--- a/imls-frontend/src/App.vue
+++ b/imls-frontend/src/App.vue
@@ -17,14 +17,14 @@ export default {
   },
   methods:{
     setRouteWrapperFocus() {
-      this.$refs.focus.focus();
+      this.$nextTick(function() {
+        this.$refs.focus.focus();
+      });
     },
   },
   watch: {
     $route: function() {
-      this.$nextTick(function() {
-        this.setRouteWrapperFocus();
-      });
+      this.setRouteWrapperFocus();
     }
   }
 };

--- a/imls-frontend/src/App.vue
+++ b/imls-frontend/src/App.vue
@@ -14,6 +14,18 @@ export default {
   metaInfo: {
     title: "Welcome",
     description: "This tool is the result of a collaborative research project with the Institute of Museum and Library Services, the Georgia Public Library Service, and Technology Transformation Services' 10x program."
+  },
+  methods:{
+    setRouteWrapperFocus() {
+      this.$refs.focus.focus();
+    },
+  },
+  watch: {
+    $route: function() {
+      this.$nextTick(function() {
+        this.setRouteWrapperFocus();
+      });
+    }
   }
 };
 </script>
@@ -30,8 +42,10 @@ export default {
       <div class="grid-container">
         <div class="grid-row grid-gap">
           <main
+            ref="focus"
             id="main-content"
             class="grid-col"
+            tabindex="-1"
           >
             <RouterView />
           </main>

--- a/imls-frontend/src/App.vue
+++ b/imls-frontend/src/App.vue
@@ -11,11 +11,19 @@ export default {
     USWDSHeader,
     USWDSFooter,
   },
+  metaInfo: {
+    title: "Welcome",
+    description: "This tool is the result of a collaborative research project with the Institute of Museum and Library Services, the Georgia Public Library Service, and Technology Transformation Services' 10x program."
+  }
 };
 </script>
 
 <template>
+
   <div>
+    <metainfo>
+      <template v-slot:title="{ content }">{{ content }} | Public Library Wifi Estimator</template>
+    </metainfo>
     <USWDSHeader />
 
     <div class="usa-section padding-top-1">

--- a/imls-frontend/src/assets/index.scss
+++ b/imls-frontend/src/assets/index.scss
@@ -33,3 +33,7 @@
 .maxw-date-picker{
   max-width: 20em;
 }
+
+main[tabindex]:focus {
+  outline: none;
+}

--- a/imls-frontend/src/assets/uswds/scss/_uswds-theme-typography.scss
+++ b/imls-frontend/src/assets/uswds/scss/_uswds-theme-typography.scss
@@ -164,7 +164,7 @@ $theme-font-type-icon: false;
 $theme-font-type-lang: false;
 
 // monospace
-$theme-font-type-mono: "roboto-mono";
+$theme-font-type-mono: "public-sans";
 
 // sans-serif
 $theme-font-type-sans: "source-sans-pro";

--- a/imls-frontend/src/components/Heatmap.spec.js
+++ b/imls-frontend/src/components/Heatmap.spec.js
@@ -51,11 +51,18 @@ describe("Heatmap", () => {
       getAlphaFromRGBAColor(allValuesRendered[3].element.style.backgroundColor)
     ).toEqual(0.4);
 
-    // the last value in the sample dataset is also the lowest percentile
+    // the last value in the sample dataset is also a zero value
     expect(allValuesRendered[14].attributes("data-percentile")).toEqual("0");
-    // 0th percentile color should have 0% alpha channel / be at 0% opacity
+    // 0th percentile color should have 0% alpha channel and have a data attribute
+    expect(allValuesRendered[14].attributes("data-is-zero")).toBeTruthy();
     expect(
       getAlphaFromRGBAColor(allValuesRendered[14].element.style.backgroundColor)
     ).toEqual(0);
+
+    // format numbers
+    expect(Heatmap.methods.formatNumbers(1)).toEqual(1);
+    // note that for now, we aren't using commas
+    expect(Heatmap.methods.formatNumbers(1000)).toEqual(1000);
+    expect(Heatmap.methods.formatNumbers(0)).toEqual('–');
   });
 });

--- a/imls-frontend/src/components/Heatmap.vue
+++ b/imls-frontend/src/components/Heatmap.vue
@@ -1,5 +1,11 @@
 <script>
 
+let formatNumbers = (val) => {
+  if (val < 1) return "–"
+  // if we prefer commas in the future, use val.toLocaleString()
+  return val
+}
+
 export default {
   name: 'HeatmapTable',
   props: {
@@ -32,6 +38,7 @@ export default {
 
   },
   methods: {
+    formatNumbers,
     sortArrayAscending(arr){
       return arr.sort(function(a,b){ return parseFloat(a) - parseFloat(b);});
     },
@@ -65,8 +72,8 @@ export default {
               {{ datasetLabels[headerIndex] }}
             </span>
           </th>
-          <td v-for="cell, i in row" :key="i" class="data-grid__cell font-mono-md text-center padding-y-2 border" :data-percentile="Math.round(getPercentile(cell)*100)" :style="{ backgroundColor: 'rgba(' + colorRGB.join() + ', ' + getPercentile(cell) +')'}">
-            {{ cell }}
+          <td v-for="cell, i in row" :key="i" class="data-grid__cell  font-mono-sm text-center padding-y-2 border" :data-percentile="Math.round(getPercentile(cell)*100)" :style="{ backgroundColor: 'rgba(' + colorRGB.join() + ', ' + getPercentile(cell) +')'}" :data-is-zero="cell === 0 ? true : null">
+            {{ formatNumbers(cell) }}
           </td>
         </tr>
       </tbody>
@@ -99,6 +106,16 @@ tr {
 th, td {
   
 }
+.data-grid__cell {
+  &[data-is-zero] {
+    color: #71767a;
+    border-color: #1b1b1b;
+    background-color: #f5f6f7 !important;
+  }
+}
+
+
+
 .data-grid__dataset {
 }
 .data-grid__dataset-label {

--- a/imls-frontend/src/components/HeatmapWeeklyCalendar.spec.js
+++ b/imls-frontend/src/components/HeatmapWeeklyCalendar.spec.js
@@ -54,7 +54,8 @@ describe("HeatmapWeeklyCalendar", () => {
 
     // the last value in the sample dataset is also the lowest percentile
     expect(allValuesRendered[13].attributes("data-percentile")).toEqual("0");
-    // 0th percentile color should have 0% alpha channel / be at 0% opacity
+    // 0th percentile color should have 0% alpha channel and have a data attribute
+    expect(allValuesRendered[13].attributes("data-is-zero")).toBeTruthy();
     expect(
       getAlphaFromRGBAColor(allValuesRendered[13].element.style.backgroundColor)
     ).toEqual(0);
@@ -66,5 +67,11 @@ describe("HeatmapWeeklyCalendar", () => {
     expect(
       wrapper.findAll(".weekly-calendar__day")[6].classes("isSelectedDate")
     ).toBe(false);
+
+    // format numbers
+    expect(HeatmapWeeklyCalendar.methods.formatNumbers(1)).toEqual(1);
+    // note that for now, we aren't using commas
+    expect(HeatmapWeeklyCalendar.methods.formatNumbers(1000)).toEqual(1000);
+    expect(HeatmapWeeklyCalendar.methods.formatNumbers(0)).toEqual('–');
   });
 });

--- a/imls-frontend/src/components/HeatmapWeeklyCalendar.vue
+++ b/imls-frontend/src/components/HeatmapWeeklyCalendar.vue
@@ -2,6 +2,13 @@
 import { store } from "@/store/store.js";
 import { addDays, parseISO, isSameDay, format } from "date-fns";
 
+let formatNumbers = (val) => {
+  if (val < 1) return "–"
+  // if we prefer commas in the future, use val.toLocaleString()
+  return val
+}
+
+
 export default {
   name: 'HeatmapWeeklyCalendar',
   props: {
@@ -45,6 +52,7 @@ export default {
     }
   },
   methods: {
+    formatNumbers,
     generateDayLabels(startingDateISO) {
       let startingDate = parseISO(startingDateISO + "T00:00");
       // 7 days = 1 week
@@ -101,8 +109,8 @@ v-for="row, headerIndex in dataset" :key="headerIndex" class="weekly-calendar__d
         <!-- A day column also has a list of values-->
         <div
 v-for="cell, index in row" :key="index" class="weekly-calendar__cell" 
-          :data-percentile="Math.round(getPercentile(cell)*100)" :style="{ backgroundColor: 'rgba(' + colorRGB.join() + ', ' + getPercentile(cell) +')'}">
-          {{ cell }}
+          :data-percentile="Math.round(getPercentile(cell)*100)" :style="{ backgroundColor: 'rgba(' + colorRGB.join() + ', ' + getPercentile(cell) +')'}" :data-is-zero="cell === 0 ? true : null">
+          {{ formatNumbers(cell) }}
         </div>
       </div>
 
@@ -133,6 +141,12 @@ v-for="cell, index in row" :key="index" class="weekly-calendar__cell"
   display: flex;
   flex-flow: column;
   justify-content: center;
+  
+  &[data-is-zero] {
+    color: #71767a;
+    border-color: #1b1b1b;
+    background-color: #f5f6f7 !important;
+  }
 }
 .weekly-calendar__day {
   border-width: 0 .25px 0 0 ;

--- a/imls-frontend/src/components/Histogram.spec.js
+++ b/imls-frontend/src/components/Histogram.spec.js
@@ -9,4 +9,10 @@ describe("Histogram", () => {
     });
     expect(wrapper.findAllComponents(Bar)).toHaveLength(1);
   });
+  it("should format numbers and replace 0 with an en dash", () => {
+    expect(Histogram.methods.formatNumbers(1)).toEqual(1);
+    // note that for now, we aren't using commas
+    expect(Histogram.methods.formatNumbers(1000)).toEqual(1000);
+    expect(Histogram.methods.formatNumbers(0)).toEqual('–');
+  });
 });

--- a/imls-frontend/src/components/Histogram.vue
+++ b/imls-frontend/src/components/Histogram.vue
@@ -3,9 +3,9 @@ import { Bar } from 'vue-chartjs'
 import { Chart as ChartJS, Title, Tooltip, BarElement, CategoryScale, LinearScale } from 'chart.js'
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 
+const Y_AXIS_SCALAR = 1.1;
 
 ChartJS.register(Title, Tooltip, BarElement, CategoryScale, LinearScale, ChartDataLabels)
-
 export default {
   name: 'BarChart',
   components: { Bar },
@@ -55,6 +55,13 @@ export default {
     return {
       chartOptions: {
         responsive: true,
+        scales: {
+          y: {
+            afterDataLimits: function(axis) {
+              axis.max *= Y_AXIS_SCALAR;
+            }
+          }
+        },
         plugins: {
           datalabels: {
             // USWSDS blue-70v
@@ -133,7 +140,6 @@ export default {
       }
     },
   },
-  methods: {}
 }
 </script>
 

--- a/imls-frontend/src/components/Histogram.vue
+++ b/imls-frontend/src/components/Histogram.vue
@@ -5,6 +5,11 @@ import ChartDataLabels from 'chartjs-plugin-datalabels';
 
 const Y_AXIS_SCALAR = 1.1;
 
+let formatNumbers = (val) => {
+  if (val < 1) return "–"
+  // if we prefer commas in the future, use val.toLocaleString()
+  return val
+}
 ChartJS.register(Title, Tooltip, BarElement, CategoryScale, LinearScale, ChartDataLabels)
 export default {
   name: 'BarChart',
@@ -56,11 +61,18 @@ export default {
       chartOptions: {
         responsive: true,
         scales: {
+          /* c8 ignore start */ 
           y: {
             afterDataLimits: function(axis) {
               axis.max *= Y_AXIS_SCALAR;
+            },
+            ticks: {
+              callback: (value, index, values) => {
+                return formatNumbers(value); 
+              }
             }
           }
+            /* c8 ignore end */ 
         },
         plugins: {
           datalabels: {
@@ -74,10 +86,15 @@ export default {
               title: {
                 font: {
                   weight: 'bold',
-                  size: 20
+                  size: 18
                 }
               },
+            },
+            /* c8 ignore start */ 
+            formatter: function(value, context) {
+              return formatNumbers(value);
             }
+            /* c8 ignore end */ 
           },
           tooltip: {
             enabled: false
@@ -140,6 +157,9 @@ export default {
       }
     },
   },
+  methods: {
+   formatNumbers
+  }
 }
 </script>
 

--- a/imls-frontend/src/components/USWDSDatePicker.spec.js
+++ b/imls-frontend/src/components/USWDSDatePicker.spec.js
@@ -1,6 +1,7 @@
 import { mount } from "@vue/test-utils";
 import USWDSDatePicker from "./USWDSDatePicker.vue";
 import { vi } from "vitest";
+import { format, startOfYesterday } from "date-fns";
 
 // don't test the external UWSDS code
 vi.mock("uswds/src/js/components/date-picker");
@@ -9,6 +10,20 @@ describe("USWDSDatePicker", () => {
   it("should render a date picker", async () => {
     const wrapper = mount(USWDSDatePicker);
     expect(wrapper.findAll(".usa-date-picker")).toHaveLength(1);
+  });
+
+  it("should limit date selections to established range", async () => {
+    const wrapper = mount(USWDSDatePicker);
+    const input = wrapper.find('.usa-input[name="date"]');
+    await input.setValue(null); // USWDS code returns null on the input for all date values outside of min/max
+    await wrapper.vm.$nextTick();
+
+    let yesterdayDateReadable = format(startOfYesterday(), 'MM/dd/yyyy')
+    expect(wrapper.vm.minDateReadable).toStrictEqual("01/01/2022");
+    expect(wrapper.vm.maxDateReadable).toStrictEqual(yesterdayDateReadable);
+
+    expect(wrapper.find("#date-outside-range")).toBeTruthy();
+    expect(USWDSDatePicker.methods.formatReadableDate("2022-02-01")).toStrictEqual("02/01/2022");
   });
 
   it("should use today's date by default", async () => {
@@ -35,6 +50,8 @@ describe("USWDSDatePicker", () => {
     expect(spyChange).toHaveBeenCalledTimes(0);
     const input = wrapper.find('.usa-input[name="date"]');
     await input.setValue("1999-12-31");
+    expect(wrapper.emitted('date_changed')).toHaveLength(1)
+    expect(wrapper.emitted('date_changed')[0]).toEqual(["1999-12-31"])
     expect(spyChange).toHaveBeenCalledTimes(1);
     await wrapper.vm.$nextTick();
   });

--- a/imls-frontend/src/components/USWDSDatePicker.vue
+++ b/imls-frontend/src/components/USWDSDatePicker.vue
@@ -27,9 +27,6 @@ export default {
       dateIsOutOfBounds: false
     }
   },
-  mounted() {
-    this.enableUSWDSFeatures();
-  },
   computed: {
     minDateReadable() {
       return this.formatReadableDate(this.minDate)
@@ -37,6 +34,9 @@ export default {
     maxDateReadable() {
       return this.formatReadableDate(this.maxDate)
     },
+  },
+  mounted() {
+    this.enableUSWDSFeatures();
   },
   methods: {
     formatReadableDate(ISO_DATE_SUBSTRING) {

--- a/imls-frontend/src/components/USWDSDatePicker.vue
+++ b/imls-frontend/src/components/USWDSDatePicker.vue
@@ -1,6 +1,6 @@
 <script>
 import datePicker from "uswds/src/js/components/date-picker";
-import { startOfYesterday } from "date-fns";
+import { format, parseISO, startOfYesterday } from "date-fns";
 
 const MIN_DATE = "2022-01-01";
 const MAX_DATE = startOfYesterday().toISOString().split("T")[0];
@@ -24,19 +24,36 @@ export default {
       selectedDate: null,
       minDate: MIN_DATE,
       maxDate: MAX_DATE,
+      dateIsOutOfBounds: false
     }
   },
   mounted() {
     this.enableUSWDSFeatures();
   },
+  computed: {
+    minDateReadable() {
+      return this.formatReadableDate(this.minDate)
+    }, 
+    maxDateReadable() {
+      return this.formatReadableDate(this.maxDate)
+    },
+  },
   methods: {
+    formatReadableDate(ISO_DATE_SUBSTRING) {
+      return format(new Date(parseISO(ISO_DATE_SUBSTRING).toISOString()), 'MM/dd/yyyy')
+    },
     async enableUSWDSFeatures(){
       await datePicker.init();
       await datePicker.enable(this.$refs.picker);
     },
     detectChange(e) {
       this.selectedDate = this.$refs.date.value;
-      this.$emit('date_changed', encodeURIComponent(e.target.value) )
+      if (this.selectedDate) {
+        this.dateIsOutOfBounds = false
+        this.$emit('date_changed', encodeURIComponent(e.target.value) )
+      } else {
+        this.dateIsOutOfBounds = true;
+      }
     }
   }
 }
@@ -52,7 +69,7 @@ export default {
 ref="picker" 
       class="usa-date-picker maxw-date-picker" 
       :data-default-value="initialDate"
-      :data-selected-date="!!selectedDate ? selectedDate : initialDate"
+      :data-selected-date="initialDate"
       :data-min-date="minDate"
       :data-max-date="maxDate"
       >
@@ -66,6 +83,7 @@ ref="picker"
         @change="detectChange"
       />
     </div>
+    <div v-if="dateIsOutOfBounds" id="date-outside-range" class="usa-hint margin-y-2">Please choose a date within range ({{  minDateReadable }} — {{ maxDateReadable }}).</div>
   </div>
 </template>
 

--- a/imls-frontend/src/components/USWDSHeader.vue
+++ b/imls-frontend/src/components/USWDSHeader.vue
@@ -47,7 +47,7 @@ export default {
               to="/"
               title="Public Library Wifi Estimator"
             > 
-            Public Library Wifi Access Estimator </RouterLink>
+            Public Library Wifi Estimator </RouterLink>
           </em>
         </div>
         <button class="usa-menu-btn">

--- a/imls-frontend/src/components/USWDSHeader.vue
+++ b/imls-frontend/src/components/USWDSHeader.vue
@@ -25,6 +25,12 @@ export default {
     resetSearch() {
       this.searchString = '';
       this.$refs.searchInput.blur()
+    },
+    // for debugging only, remove when we remove the example libraries.
+    jumpToMayForExampleLibraries(existingQuery = null, shouldJump = false) {
+      if (existingQuery.date) return existingQuery;
+      if (shouldJump) return { date: "2022-05-30" }
+      return existingQuery;
     }
   },
 };
@@ -80,9 +86,9 @@ export default {
                 id="extended-nav-section-libraries"
                 class="usa-nav__submenu"
               >
-                <li v-for="library in store.fscs_ids" :key="library.id" class="usa-nav__submenu-item">
-                  <RouterLink :to="{ path: '/library/' + library.id + '/' , query: $route.query}">
-                    Example library {{ library.id }}
+                <li v-for="library in store.example_libraries" :key="library.id" class="usa-nav__submenu-item">
+                  <RouterLink :to="{ path: '/library/' + library.id + '/' , query: jumpToMayForExampleLibraries($route.query, library.onlyMay)}">
+                    {{ library.name }}
                   </RouterLink>
                 </li>
                

--- a/imls-frontend/src/main.js
+++ b/imls-frontend/src/main.js
@@ -1,9 +1,13 @@
 import { createApp } from "vue";
 import App from "./App.vue";
 import router from "./router";
+import { createMetaManager } from 'vue-meta'
+import { plugin as vueMetaPlugin } from 'vue-meta'
 
 const app = createApp(App);
 
 app.use(router);
+app.use(createMetaManager())
+app.use(vueMetaPlugin)
 
 app.mount("#app");

--- a/imls-frontend/src/router/index.js
+++ b/imls-frontend/src/router/index.js
@@ -27,7 +27,7 @@ const routes = [
     path: "/library/:fscs_id/",
     component: () => import("../views/PageLibrary.vue"),
     props: (route) => ({
-      selectedDate: route.query.date,
+      selectedDateFromParams: route.query.date,
       id: route.params.fscs_id,
     }),
   },

--- a/imls-frontend/src/store/store.js
+++ b/imls-frontend/src/store/store.js
@@ -3,13 +3,17 @@ import { reactive, computed, readonly } from "vue";
 const BACKEND_BASEURL = import.meta.env.VITE_BACKEND_BASEURL;
 
 export const store = readonly({
-  fscs_ids: [
-    { id: "GA0029-002" },
-    { id: "GA0029-003" },
-    { id: "GA0029-004" },
-    { id: "GA0027-004" },
-    { id: "GA0027-008" },
-    { id: "GA0027-011" },
+  example_libraries: [
+    { id: "GA1234-567", name: "Meenu's Dining Room" },
+    { id: "AL1234-567", name: "Meenu's Local Library" },
+    { id: "MN9999-123", name: "Ben's Basement" },
+    { id: "MN1111-123", name: "Ben's Icy Lakes and Wilderness" },
+    { id: "GA0029-002", name: "May 2022 - Library GA0029-002", onlyMay: true },
+    { id: "GA0029-003", name: "May 2022 - Library GA0029-003", onlyMay: true  },
+    { id: "GA0029-004", name: "May 2022 - Library GA0029-004", onlyMay: true  },
+    { id: "GA0027-004", name: "May 2022 - Library GA0027-004", onlyMay: true  },
+    { id: "GA0027-008", name: "May 2022 - Library GA0027-008", onlyMay: true  },
+    { id: "GA0027-011", name: "May 2022 - Library GA0027-011", onlyMay: true  },
   ],
   hourlyLabels: [
     "12am",

--- a/imls-frontend/src/views/PageAbout.vue
+++ b/imls-frontend/src/views/PageAbout.vue
@@ -12,6 +12,9 @@ export default {
       multilineContent: "I'm the first paragraph. I get special styling in USWDS Content. \nI'm a newline. Any new lines after me are parsed as regular paragraphs. I don't know markdown yet.",
     };
   },
+  metaInfo: {
+    title: 'About',
+  }
 }
 </script>
 

--- a/imls-frontend/src/views/PageHome.vue
+++ b/imls-frontend/src/views/PageHome.vue
@@ -10,6 +10,9 @@ export default {
       store,
     };
   },
+  metaInfo: {
+    title: "Homepage",
+  }
 }
 </script>
 

--- a/imls-frontend/src/views/PageHome.vue
+++ b/imls-frontend/src/views/PageHome.vue
@@ -17,7 +17,7 @@ export default {
 </script>
 
 <template>
-  <main>
+  <div>
     <h1>Home</h1>
 
     <h2> All States</h2>
@@ -32,5 +32,5 @@ export default {
       </li>
       
     </ul>
-  </main>
+  </div>
 </template>

--- a/imls-frontend/src/views/PageLibrary.spec.js
+++ b/imls-frontend/src/views/PageLibrary.spec.js
@@ -78,7 +78,7 @@ describe("PageLibrary", () => {
     const wrapper = shallowMount(PageLibrary, {
       props: {
         id: "KnownGoodId",
-        selectedDate: "2022-05-02",
+        selectedDateFromParams: "2022-05-02",
       },
       global: {
         stubs: ["router-link", "router-view", "RouterView", "RouterLink"],
@@ -86,6 +86,21 @@ describe("PageLibrary", () => {
     });
     expect(PageLibrary.methods.toISODate(wrapper.vm.selectedDateUTC)).toEqual("2022-05-02");
     
+  });
+  it("should determine whether the provided date is usable, and if not, use yesterday", () => {
+    const wrapper = shallowMount(PageLibrary, {
+      props: {
+        id: "KnownGoodId",
+        selectedDateFromParams: "000-00-00",
+      },
+      global: {
+        stubs: ["router-link", "router-view", "RouterView", "RouterLink"],
+      },
+    });
+    expect(wrapper.vm.isParseableDate).toBeFalsy();
+    expect(wrapper.vm.selectedDateUTC).toEqual(
+       startOfYesterday()
+    );          
   });
 
   it("should format day labels for n days given a date and count", () => {
@@ -99,7 +114,7 @@ describe("PageLibrary", () => {
     const wrapper = mount(PageLibrary, {
       props: {
         id: "KnownGoodId",
-        selectedDate: "1999-12-31"
+        selectedDateFromParams: "1999-12-31"
       },
       global: {
         stubs: [
@@ -223,4 +238,6 @@ describe("PageLibrary", () => {
     expect(pageMeta).toHaveProperty("title");
     expect(pageMeta.title).toStrictEqual("prefix | postfix");
   });
+
+
 });

--- a/imls-frontend/src/views/PageLibrary.spec.js
+++ b/imls-frontend/src/views/PageLibrary.spec.js
@@ -5,7 +5,6 @@ import { createRouter, createWebHistory } from "vue-router";
 import { routes } from "../router/index.js";
 import { startOfYesterday } from "date-fns";
 
-
 let router;
 
 
@@ -189,6 +188,7 @@ describe("PageLibrary", () => {
     expect(wrapper.find("h1").text()).toEqual("MOCKED PUBLIC LIBRARY");
     expect(wrapper.vm.fetchedLibraryData).toHaveProperty('libname')
 
+
     wrapper.setProps({ id: "anotherMockedLibrary" });
     fetch.mockResponseOnce(JSON.stringify(MOCK_ANOTHER_LIB_FOUND))
     await wrapper.vm.fetchLibraryData();
@@ -218,4 +218,9 @@ describe("PageLibrary", () => {
     ).toStrictEqual("AA0001-004");
   });
 
+  it("should format a page title using the library and state names", () => {
+    let pageMeta = PageLibrary.metaInfo('prefix', 'postfix');
+    expect(pageMeta).toHaveProperty("title");
+    expect(pageMeta.title).toStrictEqual("prefix | postfix");
+  });
 });

--- a/imls-frontend/src/views/PageLibrary.vue
+++ b/imls-frontend/src/views/PageLibrary.vue
@@ -69,6 +69,14 @@ export default {
       if (this.fetchedLibraryData && this.fetchedLibraryData.libname )  return this.fetchedLibraryData.libname;
       return "Library " + this.id
     },
+    stateAbbr() {
+      if ( !this.fetchedLibraryData ) return null;
+      return this.fetchedLibraryData.stabr
+    },
+    stateName() {
+      if ( !this.fetchedLibraryData ) return null;
+      return this.store.states[this.stateAbbr]
+    },
     breadcrumbs () {
       if ( this.fetchedLibraryData == null ) return []
       return [
@@ -77,8 +85,8 @@ export default {
           link: "/" 
         },
         { 
-          name: this.store.states[this.fetchedLibraryData.stabr],
-          link: `/state/${this.fetchedLibraryData.stabr}/` 
+          name: this.stateName,
+          link: `/state/${this.stateAbbr}/` 
         },
         {
           name: this.libraryName
@@ -129,6 +137,12 @@ export default {
     },
     formatFSCSandSequence(fscsid, seq) {
       return fscsid + '-' + this.leftPadSequence(seq)
+    }
+  },
+  metaInfo(prefix = this.libraryName, postfix = this.stateName ) {
+    const pagePrefix = prefix + " | " + postfix;
+    return {
+      title: pagePrefix
     }
   }
 };

--- a/imls-frontend/src/views/PageLibrary.vue
+++ b/imls-frontend/src/views/PageLibrary.vue
@@ -23,7 +23,7 @@ export default {
       required: true,
       default: ''
     },
-    selectedDate: {
+    selectedDateFromParams: {
       type: String,
       // start at specific date if provided (for testing)
       default: () => {
@@ -43,6 +43,18 @@ export default {
     }
   },
   computed: {
+    isParseableDate() {
+      if (parseISO(this.selectedDateFromParams) == 'Invalid Date') {
+        return false
+      }
+      return true
+    },
+    selectedDate() {
+      // if selectedDateFromParams is good, use it, 
+      // otherwise use today
+      if (this.isParseableDate) return this.selectedDateFromParams
+      return startOfYesterday().toISOString().split("T")[0]
+    },
     selectedDateUTC() {
       return new Date(this.selectedDate + "T00:00")
     },
@@ -159,6 +171,8 @@ export default {
     </div>
 
     <USWDSDatePicker :initial-date=toISODate(selectedDateUTC) @date_changed="navigateToSelectedDate" />
+
+    <template v-if="isParseableDate">
 
     <div class="usa-card-group margin-top-6">
 
@@ -288,9 +302,12 @@ export default {
           </div>
         </USWDSCard>
       </div>
-
-
     </div>
+    </template>
+    <template v-else>
+      <p>Please enter a valid date.</p>
+    </template>
+
   </div>
 </template>
 

--- a/imls-frontend/src/views/PageNotFound.vue
+++ b/imls-frontend/src/views/PageNotFound.vue
@@ -7,3 +7,10 @@
 
 <style>
 </style>
+<script>
+export default {
+  metaInfo: {
+    title: "Page not found"
+  }
+}
+</script>

--- a/imls-frontend/src/views/PageNotFound.vue
+++ b/imls-frontend/src/views/PageNotFound.vue
@@ -5,8 +5,6 @@
   </div>
 </template>
 
-<style>
-</style>
 <script>
 export default {
   metaInfo: {
@@ -14,3 +12,5 @@ export default {
   }
 }
 </script>
+<style>
+</style>

--- a/imls-frontend/src/views/PageSearch.spec.js
+++ b/imls-frontend/src/views/PageSearch.spec.js
@@ -169,4 +169,10 @@ describe("PageSearch", () => {
       PageSearch.methods.formatFSCSandSequence("AA0001", "00004")
     ).toStrictEqual("AA0001-004");
   });
+
+  it("should format a page title using the current query", () => {
+    let pageMeta = PageSearch.metaInfo('searched query');
+    expect(pageMeta).toHaveProperty("title");
+    expect(pageMeta.title).toStrictEqual('Library search results for "searched query"');
+  });
 });

--- a/imls-frontend/src/views/PageSearch.vue
+++ b/imls-frontend/src/views/PageSearch.vue
@@ -49,6 +49,12 @@ export default {
       return fscsid + '-' + this.leftPadSequence(seq)
     },
   },
+  metaInfo(query = this.query) {
+    const pagePrefix = `Library search results for "${query}"`;
+    return {
+      title: pagePrefix
+    }
+  }
 }
 </script>
 

--- a/imls-frontend/src/views/PageState.spec.js
+++ b/imls-frontend/src/views/PageState.spec.js
@@ -184,4 +184,10 @@ describe("PageState", () => {
       PageState.methods.formatFSCSandSequence("AA0001", "00004")
     ).toStrictEqual("AA0001-004");
   });
+  
+  it("should format a page title using the current state name", () => {
+    let pageMeta = PageState.metaInfo('prefix');
+    expect(pageMeta).toHaveProperty("title");
+    expect(pageMeta.title).toStrictEqual("prefix Public Libraries");
+  });
 });

--- a/imls-frontend/src/views/PageState.vue
+++ b/imls-frontend/src/views/PageState.vue
@@ -79,6 +79,12 @@ export default {
     formatFSCSandSequence(fscsid, seq) {
       return fscsid + '-' + this.leftPadSequence(seq)
     },
+  },
+  metaInfo(stateName = this.stateName) {
+    const pagePrefix = `${stateName} Public Libraries`;
+    return {
+      title: pagePrefix
+    }
   }
 };
 </script>


### PR DESCRIPTION
Changes requested by Ben and Robert to make the front end better :)
- Make the page titles react to router (+ basic SEO tags)
- Make vue set focus on the main element after router nav
- Add our new test locations to the example list in the nav
- Fix a few datepicker/library page bugs so that it doesn't break when the user tries to edit the date or submits an invalid date through query params (local testing welcome, I wrote some unit tests for this but if you can break it, maybe i'll send you cookies)
  ![Screen Shot 2023-01-10 at 3 29 14 PM](https://user-images.githubusercontent.com/4451344/211666382-1e54baa0-fe6a-4a86-8632-7590b429673e.png)
- Adds some headroom to the chartJS-powered histogram so the labels added after initial render don't get cropped by the canvas, and makes the datalabels a few px smaller to fit
  
  **before:**
  ![Screen Shot 2023-01-10 at 3 32 17 PM](https://user-images.githubusercontent.com/4451344/211666879-97b9c147-7d5d-4dfd-ab9c-6243f9ca239f.png)
    
  **after:**
  ![Screen Shot 2023-01-10 at 3 32 13 PM](https://user-images.githubusercontent.com/4451344/211666872-dd0809e1-ccdc-4600-9326-dfd81fa92087.png)

- ~adds number formatting for thousands, millions, etc that abbreviates larger integers to a max of 4-5 characters~  (we will consider large number formatting at a later time)
- formats "0" values as an en dash "–" to establish visually that the data is missing, not actually zero
  ![Screen Shot 2023-01-10 at 3 24 04 PM](https://user-images.githubusercontent.com/4451344/211665717-a3658c1f-63a0-436f-8ac2-eba966f5162a.png)
