### PR TITLE
Remove -I flag, which causes RasPi a FATAL error

### DIFF
--- a/imls-wifi-sensor/internal/session-counter-helper/tlp/simpleshark.go
+++ b/imls-wifi-sensor/internal/session-counter-helper/tlp/simpleshark.go
@@ -19,7 +19,7 @@ func TSharkRunner(adapter string) []string {
 	tsharkCmd := exec.Command(
 		config.GetWiresharkPath(),
 		"-a", fmt.Sprintf("duration:%d", config.GetWiresharkDuration()),
-		"-I", "-i", adapter,
+		"-i", adapter,
 		"-Tfields", "-e", "wlan.sa")
 
 	tsharkOut, err := tsharkCmd.StdoutPipe()


### PR DESCRIPTION
Without removing the -I flag, tshark fails on RasPi with the following error:

`12:58PM FTL tshark exited unexpectedly exit status=1 stderr="Running as user \"root\" and group \"root\". This could be dangerous.\nCapturing on 'wlan1'\ntshark: The capture session could not be initiated on interface 'wlan1' (That device doesn't support monitor mode).\nPlease check that you have the proper interface or pipe specified.\n0 packets captured\n" stdout= tshark command="/usr/bin/tshark -a duration:45 -I -i wlan1 -Tfields -e wlan.sa"
`